### PR TITLE
Add mcp-get installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,12 +28,24 @@ Before you begin, ensure you have:
 You can verify your Node.js installation by running:
 ```bash
 node --version  # Should show v18.0.0 or higher
-````
+```
 
 ## Installation 🛠️
 
+### Using mcp-get (Recommended)
+
+Install the Exa MCP server using mcp-get:
+
+```bash
+npx @michaellatman/mcp-get@latest install @exa/mcp-server
+```
+
+This will handle the installation and setup automatically.
+
+### Manual Installation
+
 1.  Clone the repository:
-    
+
 
 ```
 git clone https://github.com/exa-labs/exa-mcp-server.git
@@ -41,21 +53,21 @@ cd exa-mcp-server
 ```
 
 2.  Install dependencies:
-    
+
 
 ```
 npm install --save axios dotenv
 ```
 
 3.  Build the project:
-    
+
 
 ```
 npm run build
 ```
 
 4.  Create a global link (this makes the server executable from anywhere):
-    
+
 
 ```
 npm link
@@ -74,7 +86,7 @@ or
 #### For macOS:
 
 1.  Open your Claude Desktop configuration:
-    
+
 
 ```
 code ~/Library/Application\ Support/Claude/claude_desktop_config.json
@@ -83,7 +95,7 @@ code ~/Library/Application\ Support/Claude/claude_desktop_config.json
 #### For Windows:
 
 1.  Open your Claude Desktop configuration:
-    
+
 
 ```
 code %APPDATA%\Claude\claude_desktop_config.json
@@ -91,7 +103,7 @@ code %APPDATA%\Claude\claude_desktop_config.json
 
 
 2.  Add the Exa server configuration:
-    
+
 
 ```
 {
@@ -114,11 +126,11 @@ Replace `your-api-key-here` with your actual Exa API key from [dashboard.exa.ai/
 For the changes to take effect:
 
 1.  Completely quit Claude Desktop (not just close the window)
-    
+
 2.  Start Claude Desktop again
-    
+
 3.  Look for the 🔌 icon to verify the Exa server is connected
-    
+
 
 ## Usage 🎯
 
@@ -139,67 +151,67 @@ Find and analyze recent research papers about climate change solutions.
 The server will:
 
 1.  Process the search request
-    
+
 2.  Query the Exa API
-    
+
 3.  Return formatted results to Claude
-    
+
 4.  Cache the search for future reference
-    
+
 
 ## Features ✨
 
 *   **Web Search Tool**: Enables Claude to search the web using natural language queries
-    
+
 *   **Error Handling**: Gracefully handles API errors and rate limits
-    
+
 *   **Type Safety**: Full TypeScript implementation with proper type checking
-    
+
 
 ## Troubleshooting 🔧
 
 ### Common Issues
 
 1.  **Server Not Found**
-    
+
     *   Verify the npm link is correctly set up
-        
+
     *   Check Claude Desktop configuration syntax
-        
+
     *   Ensure Node.js is properly installed
-        
+
 2.  **API Key Issues**
-    
+
     *   Confirm your Exa API key is valid
-        
+
     *   Check the API key is correctly set in the Claude Desktop config
-        
+
     *   Verify no spaces or quotes around the API key
-        
+
 3.  **Connection Issues**
-    
+
     *   Restart Claude Desktop completely
-        
+
     *   Check Claude Desktop logs:
-        
+
         ```
         # macOS
         tail -n 20 -f ~/Library/Logs/Claude/mcp*.log
         ```
-        
+
 
 ### Getting Help
 
 If you encounter issues review the [MCP Documentation](https://modelcontextprotocol.io)
-    
-    
+
+
 
 
 ## Acknowledgments 🙏
 
 *   [Exa AI](https://exa.ai) for their powerful search API
-    
+
 *   [Model Context Protocol](https://modelcontextprotocol.io) for the MCP specification
-    
+
 *   [Anthropic](https://anthropic.com) for Claude Desktop
     


### PR DESCRIPTION
This PR adds installation instructions for using mcp-get to install the Exa MCP server.

- Adds recommended mcp-get installation method at the top of Installation section
- Preserves existing manual installation instructions
- Maintains consistent documentation style

The changes make it easier for users to install the package while keeping the existing manual installation method as an alternative.