### PR TITLE
Add Smithery install instructions and update package.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,16 @@ node --version  # Should show v18.0.0 or higher
 
 ## Installation 🛠️
 
+### Using Smithery
+
+To install the Exa MCP server for Claude Desktop automatically via [Smithery](https://smithery.ai/protocol/@exa-labs/exa-mcp-server):
+
+```bash
+npx @smithery/cli install @exa-labs/exa-mcp-server --client claude
+```
+
+### Manual Installation
+
 1.  Clone the repository:
     
 

--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
-  "name": "exa-server",
+  "name": "@exa-labs/exa-mcp-server",
   "version": "0.1.0",
   "description": "A Model Context Protocol server with Exa which does web search",
   "private": true,
   "type": "module",
   "bin": {
-    "exa-server": "./build/index.js"
+    "exa-mcp-server": "./build/index.js"
   },
   "files": [
     "build"


### PR DESCRIPTION
- Add Smithery install instructions for quick installation for Claude Desktop
- Update the package.json to Exa namespace. This will still require manual `npm publish --access public` once it's ready.