### PR TITLE
Make API key optional

### DIFF
--- a/smithery.yaml
+++ b/smithery.yaml
@@ -5,8 +5,6 @@ startCommand:
   configSchema:
     # JSON Schema defining the configuration options for the MCP.
     type: object
-    required:
-      - exaApiKey
     properties:
       exaApiKey:
         type: string
@@ -14,4 +12,10 @@ startCommand:
   commandFunction:
     # A function that produces the CLI command to start the MCP on stdio.
     |-
-    (config) => ({ command: 'node', args: ['build/index.js'], env: { EXA_API_KEY: config.exaApiKey } })
+    (config) => {
+      const env = {}
+      if (config.exaApiKey) {
+        env.EXA_API_KEY = config.exaApiKey
+      }
+      return { command: 'node', args: ['build/index.js'], env }
+    }


### PR DESCRIPTION
This makes the API key optional and allows Smithery to inject a managed API key when the user does not specify their own key.