### PR TITLE
Enable all tools by default for smithery

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,3 +187,5 @@ npx exa-mcp-server --list-tools
 ---
 
 Built with ❤️ by team Exa
+
+This is a simple test sentence added to the bottom of the README.

--- a/smithery.yaml
+++ b/smithery.yaml
@@ -17,5 +17,13 @@ startCommand:
       if (config.exaApiKey) {
         env.EXA_API_KEY = config.exaApiKey
       }
-      return { command: 'node', args: ['build/index.js'], env }
+      return {
+        command: 'node',
+        args: [
+          'build/index.js',
+          '--tools',
+          'web_search_exa,research_paper_search,company_research,crawling,competitor_finder,linkedin_search,wikipedia_search_exa,github_search'
+        ],
+        env
+      }
     }

--- a/test.txt
+++ b/test.txt
@@ -1,0 +1,1 @@
+This is a test file.


### PR DESCRIPTION
After installing, users can then disable the tools they don't need through supporting client UI like this:
<img width="402" alt="image" src="https://github.com/user-attachments/assets/7645c759-03ff-4af9-857a-6e8bbe7ea236" />
Working deployment: https://smithery.ai/server/@arjunkmrm/exa-mcp-server
