### PR TITLE
Add API key and tool whitelisting details to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,13 +21,23 @@ Examples of queries you can make with `exa-code`:
   "mcpServers": {
     "exa": {
       "type": "http",
-      "url": "https://mcp.exa.ai/mcp",
+      "url": "https://mcp.exa.ai/mcp?exaApiKey=YOUREXAKEY&enabledTools=%5B%22crawling_exa%ss%5D",
       "headers": {
         "Remove-Me": "Disable web_search_exa tool if you're just coding. To 100% call exa-code, say 'use exa-code'."
       }
     }
   }
 }
+```
+
+You may include your exa api key in the url like this:
+```
+https://mcp.exa.ai/mcp?exaApiKey=YOUREXAKEY
+```
+
+You may whitelist specific tools in the url with the `enabledTools` parameter which expects a url encoded array strings like this:
+```
+https://mcp.exa.ai/mcp?exaApiKey=YOUREXAKEY&enabledTools=%5B%22crawling_exa%ss%5D
 ```
 
 You can also use `exa-code` through [Smithery](https://smithery.ai/server/exa) without an Exa API key.

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Examples of queries you can make with `exa-code`:
   "mcpServers": {
     "exa": {
       "type": "http",
-      "url": "https://mcp.exa.ai/mcp?exaApiKey=YOUREXAKEY&enabledTools=%5B%22crawling_exa%ss%5D",
+      "url": "https://mcp.exa.ai/mcp",
       "headers": {
         "Remove-Me": "Disable web_search_exa tool if you're just coding. To 100% call exa-code, say 'use exa-code'."
       }


### PR DESCRIPTION
Updated README to include API key and tool whitelisting instructions.

With the newest release, the tools previously available are not on by default:
https://github.com/exa-labs/exa-mcp-server/commit/e5e5cb23138290e8c1b17b0418c84bb622af5178

This shows how to use them.

