### PR TITLE
chore: version lock dependencies and improve package scripts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,8 @@
       "name": "exa-mcp-server",
       "version": "2.1.0",
       "dependencies": {
-        "@modelcontextprotocol/sdk": "^1.12.1",
+        "@modelcontextprotocol/sdk": "^1.18.2",
+        "@smithery/sdk": "^1.6.7",
         "axios": "^1.7.8",
         "zod": "^3.22.4"
       },
@@ -16,7 +17,7 @@
         "exa-mcp-server": ".smithery/index.cjs"
       },
       "devDependencies": {
-        "@smithery/cli": "^1.4.0",
+        "@smithery/cli": "^1.4.2",
         "@types/node": "^20.11.24",
         "tsx": "^4.7.0",
         "typescript": "^5.3.3"
@@ -811,15 +812,15 @@
       }
     },
     "node_modules/@smithery/cli": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@smithery/cli/-/cli-1.4.0.tgz",
-      "integrity": "sha512-tYVeJJ7CysLbsISuQ8HyAlvaUlRk/xPbUQwkQBC2/nv8ctOutQ8hE3XrCNZe/OP+rC6lhilzTjfyrX+XimIkUg==",
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/@smithery/cli/-/cli-1.4.2.tgz",
+      "integrity": "sha512-gCe7vzN4nMXBfohX84WkpD5vhv6iYjTfyZM0BN6ihK0ycXsFTW+cIS+6wQ9CVt/J1Ou2/Oz17+beal3yH1ukjQ==",
       "dev": true,
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.18.1",
         "@ngrok/ngrok": "^1.5.1",
         "@smithery/registry": "^0.4.1",
-        "@smithery/sdk": "^1.6.4",
+        "@smithery/sdk": "^1.6.6",
         "chalk": "^4.1.2",
         "commander": "^14.0.0",
         "cors": "^2.8.5",
@@ -853,10 +854,9 @@
       }
     },
     "node_modules/@smithery/sdk": {
-      "version": "1.6.4",
-      "resolved": "https://registry.npmjs.org/@smithery/sdk/-/sdk-1.6.4.tgz",
-      "integrity": "sha512-FJBWJW2DNFLOO5+u6ZfLLgsCVclTkd4ZTDGk+TXl7+7oUtbX+qoWeksU42XEO2I405C1BfQBKVo1R6Wp7PV3Pw==",
-      "dev": true,
+      "version": "1.6.7",
+      "resolved": "https://registry.npmjs.org/@smithery/sdk/-/sdk-1.6.7.tgz",
+      "integrity": "sha512-cyzzj28z6DVV3EBU6WWzSR+yFJdc3Ad+nPFg8Ra95hxDel3Tuziy1pOCYwnK9f5dnQ9OzvNPK0driSVqtapaBA==",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.18.0",
@@ -970,15 +970,17 @@
     "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.9.0.tgz",
-      "integrity": "sha512-re4CqKTJaURpzbLHtIi6XpDv20/CnpXOtjRY5/CU32L8gU8ek9UIivcfvSWvmKEngmVbrUtPpdDwWDWL7DNHvg==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.12.2.tgz",
+      "integrity": "sha512-vMJzPewAlRyOgxV2dU0Cuz2O8zzzx9VYtbJOaBgXFeLc4IV/Eg50n4LowmehOOR61S8ZMpc2K5Sa7g6A4jfkUw==",
+      "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.0",
+        "form-data": "^4.0.4",
         "proxy-from-env": "^1.1.0"
       }
     },
@@ -1204,6 +1206,7 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
       "dependencies": {
         "delayed-stream": "~1.0.0"
       },
@@ -1325,6 +1328,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
       }
@@ -1406,6 +1410,21 @@
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -1755,12 +1774,15 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.1.tgz",
-      "integrity": "sha512-tzN8e4TX8+kkxGPK8D5u0FNmjPUjw3lwC9lSLxxoB/+GtsJG91CO8bSWy73APlgAZzZbXEYZJuxjkHH2w+Ezhw==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
+      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
+      "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
         "mime-types": "^2.1.12"
       },
       "engines": {
@@ -1908,6 +1930,21 @@
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
       "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
       "engines": {
         "node": ">= 0.4"
       },
@@ -2218,7 +2255,6 @@
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/jose/-/jose-6.1.0.tgz",
       "integrity": "sha512-TTQJyoEoKcC1lscpVDCSsVgYzUDg/0Bt3WE//WiTPK6uOCQC2KZS4MpugbMWt/zyjkopgZoXhZuCi00gLudfUA==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/panva"
@@ -2228,7 +2264,6 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
       "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
-      "dev": true,
       "license": "(AFL-2.1 OR BSD-3-Clause)"
     },
     "node_modules/json-schema-traverse": {
@@ -2240,7 +2275,6 @@
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/log-symbols": {
@@ -2343,6 +2377,7 @@
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
       "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.6"
       }
@@ -2351,6 +2386,7 @@
       "version": "2.1.35",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
       "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
       "dependencies": {
         "mime-db": "1.52.0"
       },
@@ -2487,7 +2523,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/okay-error/-/okay-error-1.0.3.tgz",
       "integrity": "sha512-1GZkj84Uw2STYhwcGhEkgvNXkremOEmTwSgufKm9CcprjwKFuF6md5f1CIvWJgtYlyfR6BbZYnjr6HCfhUuCpQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/on-finished": {
@@ -3482,7 +3517,6 @@
       "version": "11.1.0",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
       "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
-      "dev": true,
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "exa-mcp-server",
+  "name": "exa-mcp-server-test",
   "version": "2.1.0",
   "description": "A Model Context Protocol server with Exa for web search and web crawling. Provides real-time web searches with configurable tool selection, allowing users to enable or disable specific search capabilities. Supports customizable result counts, live crawling options, and returns content from the most relevant websites.",
   "mcpName": "io.github.exa-labs/exa-mcp-server",
@@ -10,7 +10,7 @@
     "url": "git+https://github.com/exa-labs/exa-mcp-server.git"
   },
   "bin": {
-    "exa-mcp-server": "./.smithery/index.cjs"
+    "exa-mcp-server": "./stdio/.smithery/index.cjs"
   },
   "files": [
     ".smithery"
@@ -30,22 +30,23 @@
   ],
   "author": "Exa Labs",
   "scripts": {
-    "build": "npm run build:shttp",
-    "build:stdio": "npx @smithery/cli build src/index.ts --transport stdio && chmod +x .smithery/index.cjs",
-    "build:shttp": "npx @smithery/cli build src/index.ts --transport shttp",
+    "build": "npm run build:shttp && npm run build:stdio",
+    "build:stdio": "smithery build src/index.ts --transport stdio -o .smithery/stdio/index.cjs && chmod +x .smithery/stdio/index.cjs",
+    "build:shttp": "smithery build src/index.ts --transport shttp -o .smithery/shttp/index.cjs",
     "prepare": "npm run build:stdio",
     "watch": "tsc --watch",
-    "dev": "npx @smithery/cli dev",
-    "inspector": "npx @modelcontextprotocol/inspector build/index.js",
+    "dev": "smithery dev",
+    "inspector": "npx @modelcontextprotocol/inspector node .smithery/stdio/index.cjs",
     "prepublishOnly": "npm run build:stdio"
   },
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.12.1",
+    "@modelcontextprotocol/sdk": "^1.18.2",
+    "@smithery/sdk": "^1.6.7",
     "axios": "^1.7.8",
     "zod": "^3.22.4"
   },
   "devDependencies": {
-    "@smithery/cli": "^1.4.0",
+    "@smithery/cli": "^1.4.2",
     "@types/node": "^20.11.24",
     "tsx": "^4.7.0",
     "typescript": "^5.3.3"


### PR DESCRIPTION
- Add smithery/cli to dev dependencies for reproducible builds
- Add @smithery/sdk to dependencies to fix dependency issues
- Improve the following build and dev scripts

```
    "build": "npm run build:shttp && npm run build:stdio",
    "build:stdio": "smithery build src/index.ts --transport stdio -o .smithery/stdio/index.cjs && chmod +x .smithery/stdio/index.cjs",
    "build:shttp": "smithery build src/index.ts --transport shttp -o .smithery/shttp/index.cjs",
    "dev": "smithery dev",
    "inspector": "npx @modelcontextprotocol/inspector node .smithery/stdio/index.cjs",
```