### PR TITLE
refactor(linkedin-search): Improve search targeting and accuracy

### DIFF
--- a/src/tools/linkedInSearch.ts
+++ b/src/tools/linkedInSearch.ts
@@ -34,21 +34,25 @@ export function registerLinkedInSearchTool(server: McpServer, config?: { exaApiK
 
         let searchQuery = query;
         let includeDomains: string[];
+        let searchTypeValue: "keyword" | "neural";
 
         if (searchType === "profiles") {
           searchQuery = `${query}`;
           includeDomains = ["linkedin.com/in"];
+          searchTypeValue = "keyword";
         } else if (searchType === "companies") {
           searchQuery = `${query}`;
           includeDomains = ["linkedin.com/company"];
+          searchTypeValue = "keyword";
         } else {
           searchQuery = `${query}`;
           includeDomains = ["linkedin.com"];
+          searchTypeValue = "neural";
         }
 
         const searchRequest: ExaSearchRequest = {
           query: searchQuery,
-          type: "keyword",
+          type: searchTypeValue,
           numResults: numResults || API_CONFIG.DEFAULT_NUM_RESULTS,
           contents: {
             text: {


### PR DESCRIPTION
## Summary
Fixes LinkedIn search to return profile and company pages instead of post URLs, with optimized search types for better accuracy.

## Changes

### Domain Filtering
- Profile searches filter to `linkedin.com/in` only
- Company searches filter to `linkedin.com/company` only  
- General searches use broader `linkedin.com` domain
- Simplified query handling by removing redundant "LinkedIn profile/company" text additions

### Search Type Optimization
- Use **keyword** search for profile and company searches (more precise content matching on names and company names)
- Use **neural** search for general LinkedIn searches (better semantic understanding for broader queries)

## Impact
Prevents returning LinkedIn post URLs (`linkedin.com/posts/*`) when searching for user or company profiles, while maintaining semantic search quality for general LinkedIn content.