### PR TITLE
feat: expose advanced Exa API parameters

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -1,16 +1,22 @@
 // Exa API Types
 export interface ExaSearchRequest {
   query: string;
-  type: string;
+  useAutoprompt?: boolean;
+  type?: string;
   category?: string;
   includeDomains?: string[];
   excludeDomains?: string[];
   startPublishedDate?: string;
   endPublishedDate?: string;
   numResults: number;
-  contents: {
-    text: {
+  contents?: {
+    text?: {
       maxCharacters?: number;
+    } | boolean;
+    highlights?: {
+      numSentences?: number;
+      highlightsPerUrl?: number;
+      query?: string;
     } | boolean;
     livecrawl?: 'always' | 'fallback' | 'preferred';
     subpages?: number;


### PR DESCRIPTION
## Summary
Exposes Exa API parameters that were missing from the MCP tool but available in the official Exa API.

## Missing Features Now Added
The following Exa API parameters were not exposed by the MCP tool:
- `useAutoprompt` - query optimization (Exa API has this)
- `searchType` - neural/keyword/auto selection (Exa API has this)
- `startPublishedDate`/`endPublishedDate` - date filtering (Exa API has this)
- `includeDomains`/`excludeDomains` - domain filtering (Exa API has this)
- `highlights` - extractive summaries instead of full text (Exa API has this)

## Changes
- Updated TypeScript types in `src/types.ts`
- Added parameters to `web_search_exa` tool schema
- All parameters optional, maintains backward compatibility

## Testing
Tested with various parameter combinations.