### PR TITLE
fix: use explicit ./ prefix in bin path for cross-platform compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "url": "git+https://github.com/exa-labs/exa-mcp-server.git"
   },
   "bin": {
-    "exa-mcp-server": ".smithery/stdio/index.cjs"
+    "exa-mcp-server": "./.smithery/stdio/index.cjs"
   },
   "files": [
     ".smithery"


### PR DESCRIPTION
## Summary
- Adds leading `./` to the bin path in package.json for better cross-platform compatibility

## Context
Investigating #84, I found that while the current package structure is correct, earlier versions (v3.0.0-3.0.2) had mismatched bin paths that could cause npm cache issues. Adding the explicit `./` prefix follows npm best practices and ensures consistent behavior across different npm versions and operating systems.

## Test plan
- [x] Verified `npx -y exa-mcp-server` works on macOS
- [ ] Test on Linux after publish

Fixes #84

🤖 Generated with [Claude Code](https://claude.com/claude-code)