### PR TITLE
update deep mcp

### DIFF
--- a/src/tools/deepSearch.ts
+++ b/src/tools/deepSearch.ts
@@ -8,10 +8,10 @@ import { createRequestLogger } from "../utils/logger.js";
 export function registerDeepSearchTool(server: McpServer, config?: { exaApiKey?: string }): void {
   server.tool(
     "deep_search_exa",
-    "Searches the web and return results in a natural language format. Deep search uses smart query expansion and provides high-quality context for each result. You can provide additional query variations for even better results.",
+    "Searches the web and return results in a natural language format.",
     {
-      objective: z.string().describe("Query: Description of what the web search is looking for. Try to make the search query atomic - looking for a specific piece of information. May include guidance about preferred sources or freshness."),
-      search_queries: z.array(z.string()).optional().describe("Additional Queries: Optional list of additional search queries for query expansion. The search queries should be related to the objective. Only 2-4 additional queries are recommended."),
+      objective: z.string().describe("Natural language description of what the web search is looking for. Try to make the search query atomic - looking for a specific piece of information. May include guidance about preferred sources or freshness."),
+      search_queries: z.array(z.string()).optional().describe("Optional list of keyword search queries, may include search operators. The search queries should be related to the user's objective. Limited to 5 entries of up to 5 words each (around 200 characters)."),
     },
     {
       readOnlyHint: true,
@@ -40,7 +40,8 @@ export function registerDeepSearchTool(server: McpServer, config?: { exaApiKey?:
           query: objective,
           type: "deep",
           contents: {
-            context: true
+            context: false,
+            summary: true
           }
         };
         

--- a/src/tools/deepSearch.ts
+++ b/src/tools/deepSearch.ts
@@ -40,8 +40,7 @@ export function registerDeepSearchTool(server: McpServer, config?: { exaApiKey?:
           query: objective,
           type: "deep",
           contents: {
-            context: false,
-            summary: true
+            context: true
           }
         };
         


### PR DESCRIPTION
update deep prompt
make 'search_queries' param optional
use summary instead of context to avoid duplicate data (in title, url etc) - this adds no latency/cost