### PR TITLE
feat: add x-exa-integration headers to all MCP tools

### DIFF
--- a/src/tools/companyResearch.ts
+++ b/src/tools/companyResearch.ts
@@ -26,7 +26,8 @@ export function registerCompanyResearchTool(server: McpServer, config?: { exaApi
           headers: {
             'accept': 'application/json',
             'content-type': 'application/json',
-            'x-api-key': config?.exaApiKey || process.env.EXA_API_KEY || ''
+            'x-api-key': config?.exaApiKey || process.env.EXA_API_KEY || '',
+            'x-exa-integration': 'company-research-mcp'
           },
           timeout: 25000
         });
@@ -104,4 +105,4 @@ export function registerCompanyResearchTool(server: McpServer, config?: { exaApi
       }
     }
   );
-} 
+}  

--- a/src/tools/crawling.ts
+++ b/src/tools/crawling.ts
@@ -25,7 +25,8 @@ export function registerCrawlingTool(server: McpServer, config?: { exaApiKey?: s
           headers: {
             'accept': 'application/json',
             'content-type': 'application/json',
-            'x-api-key': config?.exaApiKey || process.env.EXA_API_KEY || ''
+            'x-api-key': config?.exaApiKey || process.env.EXA_API_KEY || '',
+            'x-exa-integration': 'crawling-mcp'
           },
           timeout: 25000
         });
@@ -100,4 +101,4 @@ export function registerCrawlingTool(server: McpServer, config?: { exaApiKey?: s
       }
     }
   );
-} 
+}  

--- a/src/tools/deepResearchCheck.ts
+++ b/src/tools/deepResearchCheck.ts
@@ -33,7 +33,8 @@ export function registerDeepResearchCheckTool(server: McpServer, config?: { exaA
           baseURL: API_CONFIG.BASE_URL,
           headers: {
             'accept': 'application/json',
-            'x-api-key': config?.exaApiKey || process.env.EXA_API_KEY || ''
+            'x-api-key': config?.exaApiKey || process.env.EXA_API_KEY || '',
+            'x-exa-integration': 'deep-research-mcp'
           },
           timeout: 25000
         });
@@ -161,4 +162,4 @@ export function registerDeepResearchCheckTool(server: McpServer, config?: { exaA
       }
     }
   );
-} 
+}  

--- a/src/tools/deepResearchStart.ts
+++ b/src/tools/deepResearchStart.ts
@@ -26,7 +26,8 @@ export function registerDeepResearchStartTool(server: McpServer, config?: { exaA
           headers: {
             'accept': 'application/json',
             'content-type': 'application/json',
-            'x-api-key': config?.exaApiKey || process.env.EXA_API_KEY || ''
+            'x-api-key': config?.exaApiKey || process.env.EXA_API_KEY || '',
+            'x-exa-integration': 'deep-research-mcp'
           },
           timeout: 25000
         });
@@ -106,4 +107,4 @@ export function registerDeepResearchStartTool(server: McpServer, config?: { exaA
       }
     }
   );
-} 
+}  

--- a/src/tools/deepSearch.ts
+++ b/src/tools/deepSearch.ts
@@ -31,7 +31,8 @@ export function registerDeepSearchTool(server: McpServer, config?: { exaApiKey?:
           headers: {
             'accept': 'application/json',
             'content-type': 'application/json',
-            'x-api-key': config?.exaApiKey || process.env.EXA_API_KEY || ''
+            'x-api-key': config?.exaApiKey || process.env.EXA_API_KEY || '',
+            'x-exa-integration': 'deep-search-mcp'
           },
           timeout: 25000
         });

--- a/src/tools/exaCode.ts
+++ b/src/tools/exaCode.ts
@@ -31,7 +31,8 @@ export function registerExaCodeTool(server: McpServer, config?: { exaApiKey?: st
           headers: {
             'accept': 'application/json',
             'content-type': 'application/json',
-            'x-api-key': config?.exaApiKey || process.env.EXA_API_KEY || ''
+            'x-api-key': config?.exaApiKey || process.env.EXA_API_KEY || '',
+            'x-exa-integration': 'exa-code-mcp'
           },
           timeout: 30000
         });

--- a/src/tools/linkedInSearch.ts
+++ b/src/tools/linkedInSearch.ts
@@ -27,7 +27,8 @@ export function registerLinkedInSearchTool(server: McpServer, config?: { exaApiK
           headers: {
             'accept': 'application/json',
             'content-type': 'application/json',
-            'x-api-key': config?.exaApiKey || process.env.EXA_API_KEY || ''
+            'x-api-key': config?.exaApiKey || process.env.EXA_API_KEY || '',
+            'x-exa-integration': 'linkedin-search-mcp'
           },
           timeout: 25000
         });
@@ -114,4 +115,4 @@ export function registerLinkedInSearchTool(server: McpServer, config?: { exaApiK
       }
     }
   );
-} 
+}  

--- a/src/tools/webSearch.ts
+++ b/src/tools/webSearch.ts
@@ -34,7 +34,8 @@ export function registerWebSearchTool(server: McpServer, config?: { exaApiKey?: 
           headers: {
             'accept': 'application/json',
             'content-type': 'application/json',
-            'x-api-key': config?.exaApiKey || process.env.EXA_API_KEY || ''
+            'x-api-key': config?.exaApiKey || process.env.EXA_API_KEY || '',
+            'x-exa-integration': 'web-search-mcp'
           },
           timeout: 25000
         });
@@ -112,4 +113,4 @@ export function registerWebSearchTool(server: McpServer, config?: { exaApiKey?: 
       }
     }
   );
-} 
+}  


### PR DESCRIPTION
## Summary

Adds `x-exa-integration` header to all MCP tool API requests to enable tracking MCP vs direct API usage in ClickHouse analytics. Each tool sends a distinct header value:

| Tool | Header Value |
|------|--------------|
| web_search_exa | `web-search-mcp` |
| crawling_exa | `crawling-mcp` |
| get_code_context_exa | `exa-code-mcp` |
| deep_search_exa | `deep-search-mcp` |
| linkedin_search_exa | `linkedin-search-mcp` |
| company_research_exa | `company-research-mcp` |
| deep_researcher_start | `deep-research-mcp` |
| deep_researcher_check | `deep-research-mcp` |

## Review & Testing Checklist for Human

- [ ] Verify the Exa API backend captures `x-exa-integration` header in `request_traffic.headers` (or a dedicated field) - this PR is useless without backend support
- [ ] Confirm header naming convention matches any existing integration tracking patterns (e.g., should it be `exa-code-mcp` or `get-code-context-mcp`?)
- [ ] Test one tool locally to verify the header is actually sent in requests (e.g., use network inspector or add logging)

### Notes

**Link to Devin run**: https://app.devin.ai/sessions/2a4371c8e6244965ab001b8d62284cbe
**Requested by**: adriano@exa.ai (@jld-adriano), ishan

Context: When asked "how many people are using exa-code through MCP", we found no reliable marker in ClickHouse to distinguish MCP from direct API traffic. This header enables that analysis going forward.

Related PR: https://github.com/exa-labs/exa-code-mcp/pull/2 (same change for standalone exa-code-mcp server)