### PR TITLE
Funnel through more search parameters

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -23,6 +23,9 @@ export interface ExaSearchRequest {
     subpages?: number;
     subpageTarget?: string[];
   };
+  userLocation?: string;
+  includeText?: string[];
+  excludeText?: string[];
 }
 
 export interface ExaCrawlRequest {


### PR DESCRIPTION
Fixes https://github.com/exa-labs/exa-mcp-server/issues/94

Adds: userLocation, includeDomains, excludeDomains, includeText, excludeText, startPublishedDate, endPublishedDate.

Tested with:
```bash
bun run build:stdio
bunx @modelcontextprotocol/inspector .smithery/stdio/index.cjs
```

@theishangoswami