### PR TITLE
fix: crawling_exa maxCharacters parameter not respected

### DIFF
--- a/src/tools/crawling.ts
+++ b/src/tools/crawling.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 import axios from "axios";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { API_CONFIG } from "./config.js";
+import { ExaCrawlRequest } from "../types.js";
 import { createRequestLogger } from "../utils/logger.js";
 
 export function registerCrawlingTool(server: McpServer, config?: { exaApiKey?: string }): void {
@@ -31,14 +32,12 @@ export function registerCrawlingTool(server: McpServer, config?: { exaApiKey?: s
           timeout: 25000
         });
 
-        const crawlRequest = {
+        const crawlRequest: ExaCrawlRequest = {
           ids: [url],
-          contents: {
-            text: {
-              maxCharacters: maxCharacters || API_CONFIG.DEFAULT_MAX_CHARACTERS
-            },
-            livecrawl: 'preferred'
-          }
+          text: {
+            maxCharacters: maxCharacters || API_CONFIG.DEFAULT_MAX_CHARACTERS
+          },
+          livecrawl: 'preferred'
         };
         
         logger.log("Sending crawl request to Exa API");

--- a/src/types.ts
+++ b/src/types.ts
@@ -27,7 +27,9 @@ export interface ExaSearchRequest {
 
 export interface ExaCrawlRequest {
   ids: string[];
-  text: boolean;
+  text?: {
+    maxCharacters?: number;
+  } | boolean;
   livecrawl?: 'always' | 'fallback' | 'preferred';
 }
 


### PR DESCRIPTION
## Summary

- Fixed `crawling_exa` tool ignoring the `maxCharacters` parameter
- The `/contents` endpoint expects `text` and `livecrawl` at the top level, not nested inside a `contents` wrapper
- Updated `ExaCrawlRequest` type to match actual API schema and applied it for type safety

## Root Cause

The request was structured as:
```typescript
{
  ids: [url],
  contents: {           // ❌ This wrapper was incorrect
    text: { maxCharacters: 10 },
    livecrawl: 'preferred'
  }
}
```

But the API expects:
```typescript
{
  ids: [url],
  text: { maxCharacters: 10 },  // ✅ Top-level
  livecrawl: 'preferred'        // ✅ Top-level
}
```

The API silently ignored the malformed `contents` wrapper and returned full content.

## Test plan

- [x] Verified via direct API calls that the fix respects `maxCharacters`
- [x] Tested via MCP stdio transport with `maxCharacters=10` - returns exactly 10 chars
- [x] Build succeeds with `npm run build:stdio`

🤖 Generated with [Claude Code](https://claude.com/claude-code)