### PR TITLE
fix: add 'neural' to ExaSearchRequest type union

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -1,7 +1,7 @@
 // Exa API Types
 export interface ExaSearchRequest {
   query: string;
-  type: 'auto' | 'fast' | 'deep';
+  type: 'auto' | 'neural' | 'fast' | 'deep';
   category?: string;
   includeDomains?: string[];
   excludeDomains?: string[];


### PR DESCRIPTION
## Summary

- Added `'neural'` to the `type` union in `ExaSearchRequest` interface
- Fixes TypeScript error in `linkedInSearch.ts` which uses `type: "neural"`

## Root Cause

The Exa API supports four search types: `auto`, `neural`, `fast`, and `deep`. The type definition was missing `neural`, causing:

```
src/tools/linkedInSearch.ts(47,11): error TS2322: Type '"neural"' is not assignable to type '"auto" | "fast" | "deep"'.
```

## Test plan

- [x] `npx tsc --noEmit` passes with no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)