### PR TITLE
Add title annotations to MCP tools

### DIFF
--- a/src/tools/deepSearch.ts
+++ b/src/tools/deepSearch.ts
@@ -15,6 +15,7 @@ export function registerDeepSearchTool(server: McpServer, config?: { exaApiKey?:
       search_queries: z.array(z.string()).optional().describe("Optional list of keyword search queries, may include search operators. The search queries should be related to the user's objective. Limited to 5 entries of up to 5 words each (around 200 characters)."),
     },
     {
+      title: "Deep Search",
       readOnlyHint: true,
       destructiveHint: false,
       idempotentHint: true

--- a/src/tools/exaCode.ts
+++ b/src/tools/exaCode.ts
@@ -15,6 +15,7 @@ export function registerExaCodeTool(server: McpServer, config?: { exaApiKey?: st
       tokensNum: z.number().min(1000).max(50000).default(5000).describe("Number of tokens to return (1000-50000). Default is 5000 tokens. Adjust this value based on how much context you need - use lower values for focused queries and higher values for comprehensive documentation.")
     },
     {
+      title: "Get Code Context",
       readOnlyHint: true,
       destructiveHint: false,
       idempotentHint: true

--- a/src/tools/webSearch.ts
+++ b/src/tools/webSearch.ts
@@ -18,6 +18,7 @@ export function registerWebSearchTool(server: McpServer, config?: { exaApiKey?: 
       contextMaxCharacters: z.number().optional().describe("Maximum characters for context string optimized for LLMs (default: 10000)")
     },
     {
+      title: "Web Search",
       readOnlyHint: true,
       destructiveHint: false,
       idempotentHint: true


### PR DESCRIPTION
## Summary

Added human-readable `title` property to all 3 MCP tools for improved discoverability and display in MCP clients.

### Changes

| Tool | Title |
|------|-------|
| `web_search_exa` | "Web Search" |
| `deep_search_exa` | "Deep Search" |
| `get_code_context_exa` | "Get Code Context" |

### Note

The existing `readOnlyHint`, `destructiveHint`, and `idempotentHint` annotations were already well-implemented. This PR only adds the missing `title` property for consistent tool annotation coverage.

## References

- [MCP Tool Annotations Spec](https://modelcontextprotocol.io/docs/concepts/tools#tool-annotations)

🤖 Generated with [Claude Code](https://claude.com/claude-code)