### PR TITLE
feat: Add/enhance tool annotations for improved LLM tool understanding

### DIFF
--- a/src/tools/companyResearch.ts
+++ b/src/tools/companyResearch.ts
@@ -14,6 +14,13 @@ export function registerCompanyResearchTool(server: McpServer, config?: { exaApi
       companyName: z.string().describe("Name of the company to research"),
       numResults: z.number().optional().describe("Number of search results to return (default: 5)")
     },
+    {
+      title: "Company Research",
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: true
+    },
     async ({ companyName, numResults }) => {
       const requestId = `company_research_exa-${Date.now()}-${Math.random().toString(36).substring(2, 7)}`;
       const logger = createRequestLogger(requestId, 'company_research_exa');

--- a/src/tools/crawling.ts
+++ b/src/tools/crawling.ts
@@ -13,6 +13,13 @@ export function registerCrawlingTool(server: McpServer, config?: { exaApiKey?: s
       url: z.string().describe("URL to crawl and extract content from"),
       maxCharacters: z.number().optional().describe("Maximum characters to extract (default: 3000)")
     },
+    {
+      title: "Web Crawling",
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: true
+    },
     async ({ url, maxCharacters }) => {
       const requestId = `crawling_exa-${Date.now()}-${Math.random().toString(36).substring(2, 7)}`;
       const logger = createRequestLogger(requestId, 'crawling_exa');

--- a/src/tools/deepResearchCheck.ts
+++ b/src/tools/deepResearchCheck.ts
@@ -18,6 +18,13 @@ export function registerDeepResearchCheckTool(server: McpServer, config?: { exaA
     {
       taskId: z.string().describe("The task ID returned from deep_researcher_start tool")
     },
+    {
+      title: "Check Deep Research Status",
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: true
+    },
     async ({ taskId }) => {
       const requestId = `deep_researcher_check-${Date.now()}-${Math.random().toString(36).substring(2, 7)}`;
       const logger = createRequestLogger(requestId, 'deep_researcher_check');

--- a/src/tools/deepResearchStart.ts
+++ b/src/tools/deepResearchStart.ts
@@ -14,6 +14,13 @@ export function registerDeepResearchStartTool(server: McpServer, config?: { exaA
       instructions: z.string().describe("Complex research question or detailed instructions for the AI researcher. Be specific about what you want to research and any particular aspects you want covered."),
       model: z.enum(['exa-research', 'exa-research-pro']).optional().describe("Research model: 'exa-research' (faster, 15-45s, good for most queries) or 'exa-research-pro' (more comprehensive, 45s-2min, for complex topics). Default: exa-research")
     },
+    {
+      title: "Start Deep Research",
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: false,
+      openWorldHint: true
+    },
     async ({ instructions, model }) => {
       const requestId = `deep_researcher_start-${Date.now()}-${Math.random().toString(36).substring(2, 7)}`;
       const logger = createRequestLogger(requestId, 'deep_researcher_start');

--- a/src/tools/deepSearch.ts
+++ b/src/tools/deepSearch.ts
@@ -15,9 +15,11 @@ export function registerDeepSearchTool(server: McpServer, config?: { exaApiKey?:
       search_queries: z.array(z.string()).optional().describe("Optional list of keyword search queries, may include search operators. The search queries should be related to the user's objective. Limited to 5 entries of up to 5 words each (around 200 characters)."),
     },
     {
+      title: "Deep Search",
       readOnlyHint: true,
       destructiveHint: false,
-      idempotentHint: true
+      idempotentHint: true,
+      openWorldHint: true
     },
     async ({ objective, search_queries }) => {
       const requestId = `deep_search_exa-${Date.now()}-${Math.random().toString(36).substring(2, 7)}`;

--- a/src/tools/exaCode.ts
+++ b/src/tools/exaCode.ts
@@ -15,9 +15,11 @@ export function registerExaCodeTool(server: McpServer, config?: { exaApiKey?: st
       tokensNum: z.number().min(1000).max(50000).default(5000).describe("Number of tokens to return (1000-50000). Default is 5000 tokens. Adjust this value based on how much context you need - use lower values for focused queries and higher values for comprehensive documentation.")
     },
     {
+      title: "Code Context Search",
       readOnlyHint: true,
       destructiveHint: false,
-      idempotentHint: true
+      idempotentHint: true,
+      openWorldHint: true
     },
     async ({ query, tokensNum }) => {
       const requestId = `get_code_context_exa-${Date.now()}-${Math.random().toString(36).substring(2, 7)}`;

--- a/src/tools/linkedInSearch.ts
+++ b/src/tools/linkedInSearch.ts
@@ -15,6 +15,13 @@ export function registerLinkedInSearchTool(server: McpServer, config?: { exaApiK
       searchType: z.enum(["profiles", "companies", "all"]).optional().describe("Type of LinkedIn content to search (default: all)"),
       numResults: z.number().optional().describe("Number of LinkedIn results to return (default: 5)")
     },
+    {
+      title: "LinkedIn Search",
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: true
+    },
     async ({ query, searchType, numResults }) => {
       const requestId = `linkedin_search_exa-${Date.now()}-${Math.random().toString(36).substring(2, 7)}`;
       const logger = createRequestLogger(requestId, 'linkedin_search_exa');

--- a/src/tools/webSearch.ts
+++ b/src/tools/webSearch.ts
@@ -18,9 +18,11 @@ export function registerWebSearchTool(server: McpServer, config?: { exaApiKey?: 
       contextMaxCharacters: z.number().optional().describe("Maximum characters for context string optimized for LLMs (default: 10000)")
     },
     {
+      title: "Web Search",
       readOnlyHint: true,
       destructiveHint: false,
-      idempotentHint: true
+      idempotentHint: true,
+      openWorldHint: true
     },
     async ({ query, numResults, livecrawl, type, contextMaxCharacters }) => {
       const requestId = `web_search_exa-${Date.now()}-${Math.random().toString(36).substring(2, 7)}`;


### PR DESCRIPTION
## Summary

Adds complete MCP tool annotations to all 8 tools to help LLMs better understand tool behavior and enable clients to make safer decisions about tool execution.

## Changes

### New annotations added (5 tools):
- `company_research_exa`: Company Research
- `crawling_exa`: Web Crawling
- `linkedin_search_exa`: LinkedIn Search
- `deep_researcher_start`: Start Deep Research
- `deep_researcher_check`: Check Deep Research Status

### Enhanced annotations (3 tools):
Added `title` and `openWorldHint` to existing annotations:
- `web_search_exa`: Web Search
- `deep_search_exa`: Deep Search
- `get_code_context_exa`: Code Context Search

### Annotation details for all tools:
| Tool | Title | readOnlyHint | openWorldHint | idempotentHint |
|------|-------|--------------|---------------|----------------|
| web_search_exa | Web Search | true | true | true |
| deep_search_exa | Deep Search | true | true | true |
| get_code_context_exa | Code Context Search | true | true | true |
| company_research_exa | Company Research | true | true | true |
| crawling_exa | Web Crawling | true | true | true |
| linkedin_search_exa | LinkedIn Search | true | true | true |
| deep_researcher_start | Start Deep Research | true | true | false |
| deep_researcher_check | Check Deep Research Status | true | true | true |

## Why This Matters

- **Safety**: Clients can auto-approve read-only operations without user confirmation
- **External API awareness**: `openWorldHint: true` indicates tools access external systems
- **UI improvements**: `title` provides human-readable names for display
- **Idempotency**: Helps clients understand retry behavior (all idempotent except `deep_researcher_start`)

## Testing

- [x] Build passes (`npm run build`)
- [x] All 8 tools have complete annotations
- [x] Annotations visible in bundled output

🤖 Generated with [Claude Code](https://claude.com/claude-code)