### PR TITLE
feat: Skills Architecture v3.2.0 - New Tools + Self-Documenting URLs

### DIFF
--- a/.claude/skills/exa-company-research/SKILL.md
+++ b/.claude/skills/exa-company-research/SKILL.md
@@ -1,0 +1,125 @@
+---
+name: exa-company-research
+description: Research companies comprehensively using Exa. Use when researching a company, finding competitors, analyzing financials, or gathering business intelligence. Combines web_search_advanced, company_research_exa, and crawling for thorough analysis.
+---
+
+# Company Research with Exa
+
+## When to Use
+
+- User asks about a company (e.g., "Research Stripe", "Tell me about OpenAI")
+- Competitive analysis (e.g., "Who competes with Figma?")
+- Financial research (e.g., "How is Anthropic funded?")
+- Company discovery (e.g., "Find AI startups in healthcare")
+
+## Required Tools
+
+Enable these tools in your Exa MCP config:
+- `web_search_advanced` - Full API control for category/domain filtering
+- `company_research_exa` - Company-specific research
+- `crawling_exa` - Extract content from company pages
+
+## Workflow
+
+### 1. Initial Company Search
+
+Use `web_search_advanced` with company category:
+
+```typescript
+{
+  query: "Stripe company overview funding valuation",
+  category: "company",
+  numResults: 10,
+  includeDomains: ["crunchbase.com", "bloomberg.com", "techcrunch.com", "forbes.com"],
+  enableSummary: true
+}
+```
+
+### 2. Financial Data
+
+Search financial sources:
+
+```typescript
+{
+  query: "Stripe revenue valuation 2024",
+  category: "financial report",
+  includeDomains: ["sec.gov", "bloomberg.com", "reuters.com", "wsj.com"],
+  startPublishedDate: "2024-01-01"
+}
+```
+
+### 3. News & Press
+
+Get recent news:
+
+```typescript
+{
+  query: "Stripe",
+  category: "news",
+  startPublishedDate: "2024-06-01",
+  numResults: 15,
+  enableHighlights: true,
+  highlightsPerUrl: 3
+}
+```
+
+### 4. Find Competitors
+
+Use `find_similar_exa`:
+
+```typescript
+{
+  url: "https://stripe.com",
+  category: "company",
+  numResults: 20,
+  excludeSourceDomain: true
+}
+```
+
+### 5. Deep Dive on Specific Pages
+
+Use `crawling_exa` for company pages:
+
+```typescript
+{
+  url: "https://stripe.com/about",
+  textMaxCharacters: 5000,
+  summary: true
+}
+```
+
+## Pro Tips
+
+1. **Layer your searches** - Start broad (company category), then narrow (financial reports, news)
+2. **Use date filters** - Recent news + historical for trends
+3. **Domain whitelists** - Trusted sources: crunchbase.com, pitchbook.com, bloomberg.com
+4. **Highlights for scanning** - Enable highlights when processing many results
+5. **Summaries for synthesis** - Use summaryQuery to focus on specific aspects
+
+## Example Output Structure
+
+```markdown
+# Company Research: [Company Name]
+
+## Overview
+[Summary from company pages and Crunchbase]
+
+## Funding & Financials
+- Total raised: $X
+- Valuation: $X
+- Recent rounds: [details]
+
+## Competitors
+1. [Competitor 1] - [brief comparison]
+2. [Competitor 2] - [brief comparison]
+
+## Recent News
+- [Date]: [Headline] - [Summary]
+
+## Key People
+- CEO: [Name]
+- Founded: [Year]
+
+## Sources
+[List of URLs used]
+```

--- a/.claude/skills/exa-gtm/SKILL.md
+++ b/.claude/skills/exa-gtm/SKILL.md
@@ -1,0 +1,194 @@
+---
+name: exa-gtm
+description: Sales and GTM research workflows using Exa. Use when prospecting, building account lists, preparing for sales calls, or researching potential customers. Combines company research with people finding for sales intelligence.
+---
+
+# GTM & Sales Research with Exa
+
+## When to Use
+
+- Building prospect lists (e.g., "Find fintech startups in NYC")
+- Account research (e.g., "Research Acme Corp before my call")
+- Finding decision makers (e.g., "Who should I contact at Stripe?")
+- Competitive intel (e.g., "What are Stripe's customers saying?")
+
+## Required Tools
+
+Enable these tools in your Exa MCP config:
+- `web_search_advanced` - Full API for company/people search
+- `linkedin_search_exa` - Find decision makers
+- `company_research_exa` - Company intel
+- `crawling_exa` - Extract detailed info
+
+## Prospecting Workflows
+
+### 1. Build Target Account List
+
+Find companies matching your ICP:
+
+```typescript
+{
+  query: "Series B fintech startup payments infrastructure",
+  category: "company",
+  numResults: 30,
+  includeDomains: ["crunchbase.com", "techcrunch.com"],
+  startPublishedDate: "2023-01-01",
+  enableSummary: true,
+  summaryQuery: "funding, product, team size"
+}
+```
+
+### 2. Find Similar Companies
+
+From a known good customer:
+
+```typescript
+{
+  url: "https://goodcustomer.com",
+  category: "company",
+  numResults: 50,
+  excludeSourceDomain: true
+}
+```
+
+### 3. Find Decision Makers
+
+Search for the right contacts:
+
+```typescript
+{
+  query: "VP Engineering Head of Platform Stripe",
+  category: "people",
+  includeDomains: ["linkedin.com"],
+  numResults: 20
+}
+```
+
+## Pre-Call Research
+
+### 1. Company Overview
+
+```typescript
+{
+  query: "Acme Corp company overview product funding",
+  category: "company",
+  numResults: 10,
+  enableSummary: true
+}
+```
+
+### 2. Recent News
+
+```typescript
+{
+  query: "Acme Corp",
+  category: "news",
+  startPublishedDate: "2024-01-01",
+  numResults: 10,
+  enableHighlights: true
+}
+```
+
+### 3. Tech Stack
+
+```typescript
+{
+  query: "Acme Corp technology stack engineering blog",
+  includeDomains: ["stackshare.io", "builtwith.com", "github.com"],
+  numResults: 10
+}
+```
+
+### 4. Key People
+
+```typescript
+{
+  query: "Acme Corp executives leadership CTO VP Engineering",
+  category: "people",
+  numResults: 15
+}
+```
+
+### 5. Pain Points
+
+Search for challenges:
+
+```typescript
+{
+  query: "Acme Corp challenges problems scaling",
+  category: "news",
+  startPublishedDate: "2023-01-01",
+  enableHighlights: true,
+  highlightsQuery: "challenges problems pain points"
+}
+```
+
+## Competitive Intelligence
+
+### Customer Sentiment
+
+```typescript
+{
+  query: "competitor-name review customer feedback",
+  excludeDomains: ["competitor-name.com"],
+  category: "personal site",
+  enableHighlights: true,
+  highlightsQuery: "pros cons issues"
+}
+```
+
+### Product Comparisons
+
+```typescript
+{
+  query: "competitor-name vs alternative comparison",
+  category: "news",
+  numResults: 20
+}
+```
+
+## Pro Tips
+
+1. **Layer searches** - Company first, then people, then news
+2. **Use date filters** - Recent news shows current state
+3. **Highlight pain points** - Use highlightsQuery for challenges
+4. **Batch similar companies** - Use find_similar for ICP expansion
+5. **Tech stack research** - GitHub, StackShare reveal infrastructure
+
+## Example Output: Pre-Call Brief
+
+```markdown
+# Account Brief: [Company Name]
+
+## Quick Facts
+- Founded: [Year]
+- Funding: [Total raised, Last round]
+- Size: [Employee count]
+- HQ: [Location]
+
+## What They Do
+[2-3 sentence summary]
+
+## Recent News
+- [Date]: [Headline + key point]
+- [Date]: [Headline + key point]
+
+## Key Contacts
+- [Name], [Title] - [LinkedIn URL]
+- [Name], [Title] - [LinkedIn URL]
+
+## Potential Pain Points
+- [Challenge 1]
+- [Challenge 2]
+
+## Tech Stack
+- [Known technologies]
+
+## Talking Points
+1. [Point based on their recent news]
+2. [Point based on their industry]
+3. [Point based on their tech stack]
+
+## Sources
+[URLs]
+```

--- a/.claude/skills/exa-people-research/SKILL.md
+++ b/.claude/skills/exa-people-research/SKILL.md
@@ -1,0 +1,158 @@
+---
+name: exa-people-research
+description: Research individuals using Exa. Use when finding information about a person, their background, work history, or public presence. Combines linkedin_search_exa with web_search_advanced for comprehensive people research.
+---
+
+# People Research with Exa
+
+## When to Use
+
+- Finding someone's background (e.g., "Who is Sam Altman?")
+- Pre-meeting research (e.g., "Research the CEO of Company X")
+- Finding experts (e.g., "Find AI researchers at Stanford")
+- Contact discovery (e.g., "Find the VP of Engineering at Stripe")
+
+## Required Tools
+
+Enable these tools in your Exa MCP config:
+- `linkedin_search_exa` - LinkedIn profile search
+- `web_search_advanced` - Full API for people category
+- `crawling_exa` - Extract content from personal sites
+
+## Workflow
+
+### 1. LinkedIn Profile Search
+
+Use `linkedin_search_exa`:
+
+```typescript
+{
+  query: "Sam Altman OpenAI CEO",
+  numResults: 5
+}
+```
+
+### 2. People Category Search
+
+Use `web_search_advanced` with people category:
+
+```typescript
+{
+  query: "Sam Altman background career history",
+  category: "people",
+  numResults: 10,
+  enableSummary: true
+}
+```
+
+### 3. Personal Sites & Blogs
+
+Search personal content:
+
+```typescript
+{
+  query: "Sam Altman",
+  category: "personal site",
+  numResults: 10,
+  includeDomains: ["substack.com", "medium.com", "github.com"],
+  enableHighlights: true
+}
+```
+
+### 4. Twitter/X Presence
+
+Find social presence:
+
+```typescript
+{
+  query: "Sam Altman",
+  category: "tweet",
+  numResults: 20,
+  startPublishedDate: "2024-01-01"
+}
+```
+
+### 5. News Mentions
+
+Find press coverage:
+
+```typescript
+{
+  query: "Sam Altman",
+  category: "news",
+  startPublishedDate: "2024-06-01",
+  numResults: 15
+}
+```
+
+### 6. Extract Personal Site
+
+If they have a personal site, crawl it:
+
+```typescript
+{
+  url: "https://samaltman.com",
+  textMaxCharacters: 10000,
+  subpages: 5,
+  subpageTarget: ["about", "bio", "writing"]
+}
+```
+
+## Finding People at Companies
+
+### Find Executives
+
+```typescript
+{
+  query: "Anthropic executives leadership team",
+  category: "people",
+  includeDomains: ["linkedin.com", "anthropic.com"],
+  numResults: 20
+}
+```
+
+### Find by Role
+
+```typescript
+{
+  query: "VP Engineering Stripe",
+  category: "people",
+  numResults: 10
+}
+```
+
+## Pro Tips
+
+1. **Combine categories** - LinkedIn for career, personal sites for personality, news for recent activity
+2. **Use subpage crawling** - Personal sites often have about/bio pages
+3. **Date filter for recency** - Filter news to last 6 months for current role
+4. **Domain targeting** - linkedin.com, twitter.com, personal domains
+5. **Highlight quotes** - Enable highlights to find direct quotes
+
+## Example Output Structure
+
+```markdown
+# Person Profile: [Name]
+
+## Current Role
+[Title] at [Company] (since [Year])
+
+## Background
+- Education: [Degrees, Schools]
+- Previous roles: [List]
+- Known for: [Achievements]
+
+## Online Presence
+- LinkedIn: [URL]
+- Twitter: [URL]
+- Personal site: [URL]
+
+## Recent Activity
+- [Date]: [Event/Quote/News]
+
+## Public Quotes
+> "[Quote]" - [Source]
+
+## Sources
+[List of URLs used]
+```

--- a/.claude/skills/exa-research-paper/SKILL.md
+++ b/.claude/skills/exa-research-paper/SKILL.md
@@ -1,0 +1,204 @@
+---
+name: exa-research-paper
+description: Academic and scientific research using Exa. Use when finding research papers, academic citations, scientific studies, or technical documentation. Leverages research paper category with highlights and summaries for efficient literature review.
+---
+
+# Academic Research with Exa
+
+## When to Use
+
+- Literature review (e.g., "Find papers on transformer architectures")
+- Finding citations (e.g., "Papers that cite Attention Is All You Need")
+- Technical deep dives (e.g., "How does RLHF work?")
+- State of the art (e.g., "Latest research in protein folding")
+
+## Required Tools
+
+Enable these tools in your Exa MCP config:
+- `web_search_advanced` - Research paper category + PDF support
+- `answer_exa` - Direct answers with academic citations
+- `crawl_urls_exa` - Extract full paper content
+- `find_similar_exa` - Find related papers
+
+## Research Workflows
+
+### 1. Find Papers on a Topic
+
+```typescript
+{
+  query: "transformer attention mechanisms efficient inference",
+  category: "research paper",
+  numResults: 20,
+  includeDomains: ["arxiv.org", "openreview.net", "aclanthology.org"],
+  startPublishedDate: "2023-01-01",
+  enableSummary: true,
+  summaryQuery: "method, results, contribution"
+}
+```
+
+### 2. Find Seminal Papers
+
+Search without date filter for foundational work:
+
+```typescript
+{
+  query: "attention is all you need transformer original paper",
+  category: "research paper",
+  numResults: 10
+}
+```
+
+### 3. Find Related Papers
+
+From a paper you like:
+
+```typescript
+{
+  url: "https://arxiv.org/abs/1706.03762",
+  category: "research paper",
+  numResults: 30
+}
+```
+
+### 4. Get Quick Answers
+
+Use `answer_exa` for factual questions:
+
+```typescript
+{
+  query: "What is the computational complexity of self-attention?",
+  category: "research paper",
+  numResults: 5
+}
+```
+
+### 5. Extract Paper Content
+
+Crawl for full text:
+
+```typescript
+{
+  urls: ["https://arxiv.org/abs/2301.00234"],
+  textMaxCharacters: 20000,
+  enableSummary: true,
+  enableHighlights: true,
+  highlightsPerUrl: 10,
+  highlightsQuery: "key findings contributions results"
+}
+```
+
+## Advanced Searches
+
+### By Conference/Venue
+
+```typescript
+{
+  query: "NeurIPS 2024 language models",
+  category: "research paper",
+  includeDomains: ["neurips.cc", "openreview.net"],
+  startPublishedDate: "2024-01-01"
+}
+```
+
+### By Institution
+
+```typescript
+{
+  query: "Google DeepMind reinforcement learning",
+  category: "research paper",
+  startPublishedDate: "2024-01-01",
+  numResults: 20
+}
+```
+
+### Technical Documentation
+
+```typescript
+{
+  query: "PyTorch distributed training API",
+  category: "pdf",
+  includeDomains: ["pytorch.org", "github.com"],
+  enableHighlights: true
+}
+```
+
+### GitHub Implementations
+
+```typescript
+{
+  query: "flash attention implementation CUDA",
+  category: "github",
+  numResults: 15
+}
+```
+
+## Pro Tips
+
+1. **Use research paper category** - Filters to academic sources
+2. **Domain whitelist** - arxiv.org, openreview.net, aclanthology.org, neurips.cc
+3. **Date ranges** - Recent for SOTA, no filter for foundational
+4. **Summaries** - Use summaryQuery: "method, results, limitations"
+5. **Highlights for scanning** - Key findings without reading full paper
+6. **Find similar** - One good paper leads to related work
+
+## Literature Review Template
+
+```markdown
+# Literature Review: [Topic]
+
+## Overview
+[Summary of the field]
+
+## Key Papers
+
+### [Paper Title 1]
+- Authors: [Names]
+- Year: [Year]
+- Venue: [Conference/Journal]
+- Key contribution: [Summary]
+- URL: [arXiv/DOI]
+
+### [Paper Title 2]
+...
+
+## State of the Art
+[Current best approaches]
+
+## Open Problems
+[Gaps in research]
+
+## Trends
+[Direction the field is moving]
+
+## References
+[Full citation list]
+```
+
+## Example: Quick Paper Summary
+
+```markdown
+# Paper Summary
+
+**Title:** [Title]
+**Authors:** [Names]
+**Year:** [Year]
+
+## Problem
+What problem does this paper solve?
+
+## Method
+How do they solve it?
+
+## Results
+What did they achieve?
+
+## Limitations
+What are the caveats?
+
+## Key Quotes
+> "[Important quote]" (p. X)
+
+## Related Work
+- [Paper 1]
+- [Paper 2]
+```

--- a/.claude/skills/exa-web-chunker/SKILL.md
+++ b/.claude/skills/exa-web-chunker/SKILL.md
@@ -1,0 +1,241 @@
+---
+name: exa-web-chunker
+description: Advanced web content extraction and chunking using Exa. Use when you need to thoroughly extract content from websites, crawl multiple pages, or build comprehensive knowledge from web sources. Leverages subpages, highlights, and batch crawling for deep extraction.
+---
+
+# Web Content Extraction with Exa
+
+## When to Use
+
+- Documentation extraction (e.g., "Get all docs from React")
+- Blog/article harvesting (e.g., "Get all posts from this blog")
+- Site mapping (e.g., "What pages are on this site?")
+- Content aggregation (e.g., "Gather info from these 10 URLs")
+
+## Required Tools
+
+Enable these tools in your Exa MCP config:
+- `crawl_urls_exa` - Batch URL crawling with options
+- `web_search_advanced` - Search + subpage crawling
+- `crawling_exa` - Single URL extraction
+
+## Extraction Workflows
+
+### 1. Single Page Extraction
+
+Basic content extraction:
+
+```typescript
+// Using crawl_urls_exa
+{
+  urls: ["https://example.com/docs/getting-started"],
+  textMaxCharacters: 10000,
+  enableSummary: true,
+  enableHighlights: true,
+  highlightsPerUrl: 5
+}
+```
+
+### 2. Batch URL Processing
+
+Process multiple known URLs:
+
+```typescript
+{
+  urls: [
+    "https://example.com/page1",
+    "https://example.com/page2",
+    "https://example.com/page3"
+  ],
+  textMaxCharacters: 5000,
+  enableSummary: true,
+  summaryQuery: "main points and key information",
+  livecrawl: "always"
+}
+```
+
+### 3. Subpage Crawling
+
+Crawl a page plus its linked pages:
+
+```typescript
+// Using web_search_advanced or crawl_urls_exa
+{
+  urls: ["https://docs.example.com"],
+  subpages: 10,
+  subpageTarget: ["getting started", "tutorial", "guide", "api"],
+  textMaxCharacters: 3000,
+  enableSummary: true
+}
+```
+
+### 4. Documentation Harvesting
+
+Get all docs from a site:
+
+```typescript
+{
+  query: "site:docs.react.dev tutorial guide",
+  type: "auto",
+  numResults: 50,
+  includeDomains: ["docs.react.dev"],
+  textMaxCharacters: 5000,
+  enableHighlights: true,
+  highlightsPerUrl: 5,
+  highlightsQuery: "key concept important"
+}
+```
+
+### 5. Blog Archive Extraction
+
+Get blog posts:
+
+```typescript
+{
+  query: "site:blog.example.com",
+  type: "auto",
+  numResults: 30,
+  category: "personal site",
+  startPublishedDate: "2024-01-01",
+  enableSummary: true
+}
+```
+
+## Advanced Patterns
+
+### Link Extraction
+
+Get URLs from a page:
+
+```typescript
+{
+  urls: ["https://example.com/resources"],
+  extractLinks: 50,
+  textMaxCharacters: 1000
+}
+```
+
+### Image Extraction
+
+Get images:
+
+```typescript
+{
+  urls: ["https://example.com/gallery"],
+  extractImages: 20,
+  textMaxCharacters: 500
+}
+```
+
+### Live Crawl for Fresh Content
+
+Force fresh crawl:
+
+```typescript
+{
+  urls: ["https://news.example.com"],
+  livecrawl: "always",
+  livecrawlTimeout: 30000,
+  textMaxCharacters: 5000
+}
+```
+
+### Targeted Highlights
+
+Extract specific information:
+
+```typescript
+{
+  urls: ["https://example.com/pricing"],
+  enableHighlights: true,
+  highlightsPerUrl: 10,
+  highlightsQuery: "price cost tier plan features",
+  highlightsNumSentences: 2
+}
+```
+
+## Chunking Strategies
+
+### For Long Documents
+
+```typescript
+// Crawl with manageable chunks
+{
+  urls: ["https://example.com/long-doc"],
+  textMaxCharacters: 3000,  // Smaller chunks
+  enableHighlights: true,
+  highlightsPerUrl: 10,
+  enableSummary: true
+}
+```
+
+### For Multiple Pages
+
+```typescript
+// Summary-first approach
+{
+  urls: [...arrayOf20Urls],
+  textMaxCharacters: 1000,  // Brief per page
+  enableSummary: true,
+  summaryQuery: "main topic and key points"
+}
+```
+
+## Pro Tips
+
+1. **textMaxCharacters** - Adjust based on how many URLs (more URLs = smaller per URL)
+2. **subpages** - Use for documentation sites, limit to 5-10 for focus
+3. **subpageTarget** - Keywords that match the pages you want
+4. **livecrawl: always** - For news/frequently updated content
+5. **Highlights** - Extract key sentences without full text
+6. **Summaries** - Get overview before deciding to get full text
+
+## Output Templates
+
+### Documentation Index
+
+```markdown
+# Documentation: [Product Name]
+
+## Pages Crawled
+1. [Page Title] - [URL]
+   Summary: [Summary]
+
+2. [Page Title] - [URL]
+   Summary: [Summary]
+
+## Key Concepts
+- [Concept 1]: [Explanation from highlights]
+- [Concept 2]: [Explanation from highlights]
+
+## Code Examples Found
+```[language]
+[Code snippet from content]
+```
+
+## Links to Explore
+- [Link 1]
+- [Link 2]
+```
+
+### Content Digest
+
+```markdown
+# Content Digest: [Topic/Source]
+
+## Sources
+[List of URLs processed]
+
+## Summary
+[Overall synthesis]
+
+## Key Points
+1. [Point from highlights]
+2. [Point from highlights]
+
+## Notable Quotes
+> "[Quote]" - [Source URL]
+
+## Related Links
+[Extracted links for further reading]
+```

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,0 +1,407 @@
+# Exa MCP Server - Installation & Configuration
+
+> AI-powered web search for Claude Desktop, Cursor, and Claude Code
+
+## Quick Start
+
+### Claude Desktop
+
+Add to `~/Library/Application Support/Claude/claude_desktop_config.json` (Mac) or `%APPDATA%\Claude\claude_desktop_config.json` (Windows):
+
+```json
+{
+  "mcpServers": {
+    "exa": {
+      "command": "npx",
+      "args": ["-y", "exa-mcp-server"],
+      "env": {
+        "EXA_API_KEY": "your-api-key"
+      }
+    }
+  }
+}
+```
+
+### Cursor / Claude Code (HTTP)
+
+```json
+{
+  "mcpServers": {
+    "exa": {
+      "type": "http",
+      "url": "https://mcp.exa.ai/mcp",
+      "headers": {
+        "x-api-key": "your-api-key"
+      }
+    }
+  }
+}
+```
+
+---
+
+## Configuration Presets
+
+Choose a preset based on your use case. All presets use the self-documenting `enabled`/`disabled` pattern.
+
+### Basic Search (Default)
+
+Web search + code context. Good for general use.
+
+**CLI:**
+```bash
+npx exa-mcp-server --enabled=web_search_exa,get_code_context_exa
+```
+
+**HTTP:**
+```
+https://mcp.exa.ai/mcp?enabled=web_search_exa,get_code_context_exa
+```
+
+**Enabled:** `web_search_exa`, `get_code_context_exa`
+**Disabled:** `web_search_advanced`, `find_similar_exa`, `answer_exa`, `crawl_urls_exa`, `deep_search_exa`, `crawling_exa`, `deep_researcher_start`, `deep_researcher_check`, `linkedin_search_exa`, `company_research_exa`
+
+---
+
+### Power User
+
+All search tools with full API control.
+
+**CLI:**
+```bash
+npx exa-mcp-server --enabled=web_search_exa,web_search_advanced,get_code_context_exa,find_similar_exa,answer_exa,crawl_urls_exa
+```
+
+**HTTP:**
+```
+https://mcp.exa.ai/mcp?enabled=web_search_exa,web_search_advanced,get_code_context_exa,find_similar_exa,answer_exa,crawl_urls_exa
+```
+
+**Enabled:** `web_search_exa`, `web_search_advanced`, `get_code_context_exa`, `find_similar_exa`, `answer_exa`, `crawl_urls_exa`
+**Disabled:** `deep_search_exa`, `crawling_exa`, `deep_researcher_start`, `deep_researcher_check`, `linkedin_search_exa`, `company_research_exa`
+
+---
+
+### Company Research
+
+Research companies from Bloomberg, SEC, news sources.
+
+**CLI:**
+```bash
+npx exa-mcp-server --enabled=web_search_exa,web_search_advanced,company_research_exa,deep_search_exa,crawling_exa
+```
+
+**HTTP:**
+```
+https://mcp.exa.ai/mcp?enabled=web_search_exa,web_search_advanced,company_research_exa,deep_search_exa,crawling_exa
+```
+
+**Enabled:** `web_search_exa`, `web_search_advanced`, `company_research_exa`, `deep_search_exa`, `crawling_exa`
+**Disabled:** `get_code_context_exa`, `find_similar_exa`, `answer_exa`, `crawl_urls_exa`, `deep_researcher_start`, `deep_researcher_check`, `linkedin_search_exa`
+
+---
+
+### GTM / Sales
+
+Prospect research with company + people data.
+
+**CLI:**
+```bash
+npx exa-mcp-server --enabled=web_search_exa,web_search_advanced,company_research_exa,linkedin_search_exa,crawling_exa
+```
+
+**HTTP:**
+```
+https://mcp.exa.ai/mcp?enabled=web_search_exa,web_search_advanced,company_research_exa,linkedin_search_exa,crawling_exa
+```
+
+**Enabled:** `web_search_exa`, `web_search_advanced`, `company_research_exa`, `linkedin_search_exa`, `crawling_exa`
+**Disabled:** `get_code_context_exa`, `find_similar_exa`, `answer_exa`, `crawl_urls_exa`, `deep_search_exa`, `deep_researcher_start`, `deep_researcher_check`
+
+---
+
+### Full Power
+
+Everything enabled. For power users and custom skills.
+
+**CLI:**
+```bash
+npx exa-mcp-server --enabled=web_search_exa,web_search_advanced,get_code_context_exa,find_similar_exa,answer_exa,crawl_urls_exa,deep_search_exa,crawling_exa,deep_researcher_start,deep_researcher_check,linkedin_search_exa,company_research_exa
+```
+
+**HTTP:**
+```
+https://mcp.exa.ai/mcp?enabled=web_search_exa,web_search_advanced,get_code_context_exa,find_similar_exa,answer_exa,crawl_urls_exa,deep_search_exa,crawling_exa,deep_researcher_start,deep_researcher_check,linkedin_search_exa,company_research_exa
+```
+
+**Enabled:** All 12 tools
+**Disabled:** None
+
+---
+
+## Available Tools (12 Total)
+
+| Tool ID | Name | Description | Default |
+|---------|------|-------------|---------|
+| `web_search_exa` | Web Search | Real-time web search with basic params | Enabled |
+| `web_search_advanced` | Advanced Web Search | Full API control: categories, domains, dates, highlights, summaries, subpages | Disabled |
+| `get_code_context_exa` | Code Context | Search code, docs, and examples from open source repos | Enabled |
+| `find_similar_exa` | Find Similar | Find web pages similar to a given URL | Disabled |
+| `answer_exa` | Answer | Get direct answers with citations | Disabled |
+| `crawl_urls_exa` | Crawl URLs | Batch crawl URLs with advanced extraction | Disabled |
+| `deep_search_exa` | Deep Search | Query expansion + high-quality summaries | Disabled |
+| `crawling_exa` | Web Crawling | Extract content from specific URLs | Disabled |
+| `deep_researcher_start` | Deep Researcher Start | Start comprehensive AI research task | Disabled |
+| `deep_researcher_check` | Deep Researcher Check | Check research task status/results | Disabled |
+| `linkedin_search_exa` | LinkedIn Search | Search LinkedIn profiles and companies | Disabled |
+| `company_research_exa` | Company Research | Research companies and organizations | Disabled |
+
+---
+
+## Tool Parameters Reference
+
+### web_search_exa (Simple)
+
+Basic web search for everyday use.
+
+```typescript
+query: string           // Search query
+numResults?: number     // 1-100 (default: 8)
+type?: 'auto' | 'fast' | 'deep'  // Search type (default: 'auto')
+```
+
+---
+
+### web_search_advanced (Full API)
+
+Full Exa API surface for building skills and advanced workflows.
+
+```typescript
+// Core
+query: string
+numResults?: number     // 1-100 (default: 8)
+type?: 'auto' | 'fast' | 'deep' | 'neural'
+
+// Category filtering
+category?: 'company' | 'research paper' | 'news' | 'pdf' | 'github' |
+           'tweet' | 'personal site' | 'people' | 'financial report'
+
+// Domain filtering (up to 1200 domains each)
+includeDomains?: string[]
+excludeDomains?: string[]
+
+// Date filtering (ISO 8601: YYYY-MM-DD)
+startPublishedDate?: string
+endPublishedDate?: string
+startCrawlDate?: string
+endCrawlDate?: string
+
+// Content filtering
+includeText?: string[]  // Required text in results
+excludeText?: string[]  // Excluded text
+
+// Geo-targeting
+userLocation?: string   // ISO country code (e.g., "US")
+
+// Content moderation
+moderation?: boolean    // Filter unsafe content
+
+// Livecrawl options
+livecrawl?: 'never' | 'fallback' | 'always' | 'preferred'
+livecrawlTimeout?: number  // Timeout in ms
+
+// Text extraction
+textMaxCharacters?: number
+
+// Highlights extraction
+enableHighlights?: boolean
+highlightsNumSentences?: number
+highlightsPerUrl?: number
+highlightsQuery?: string
+
+// Summary generation
+enableSummary?: boolean
+summaryQuery?: string
+
+// Subpage crawling
+subpages?: number       // 1-10
+subpageTarget?: string[]
+
+// Extras
+extractLinks?: number   // URLs per page
+extractImages?: number  // Images per result
+
+// Query expansion
+additionalQueries?: string[]
+```
+
+---
+
+### find_similar_exa
+
+Find web pages similar to a given URL.
+
+```typescript
+url: string             // URL to find similar content for
+numResults?: number     // 1-100 (default: 10)
+includeDomains?: string[]
+excludeDomains?: string[]
+startPublishedDate?: string
+endPublishedDate?: string
+category?: 'company' | 'research paper' | 'news' | 'pdf' | 'github' |
+           'tweet' | 'personal site' | 'people' | 'financial report'
+excludeSourceDomain?: boolean  // Exclude source URL's domain (default: true)
+textMaxCharacters?: number
+contextMaxCharacters?: number  // (default: 10000)
+```
+
+---
+
+### answer_exa
+
+Get a direct answer with citations from the web.
+
+```typescript
+query: string           // Question to answer
+numResults?: number     // Number of sources (1-20, default: 5)
+includeDomains?: string[]
+excludeDomains?: string[]
+startPublishedDate?: string
+endPublishedDate?: string
+category?: 'company' | 'research paper' | 'news' | 'pdf' | 'github' |
+           'tweet' | 'personal site' | 'people' | 'financial report'
+```
+
+---
+
+### crawl_urls_exa
+
+Crawl and extract content from multiple URLs.
+
+```typescript
+urls: string[]          // URLs to crawl
+textMaxCharacters?: number
+enableSummary?: boolean
+summaryQuery?: string   // Focus query for summary
+enableHighlights?: boolean
+highlightsNumSentences?: number
+highlightsPerUrl?: number
+highlightsQuery?: string
+livecrawl?: 'never' | 'fallback' | 'always' | 'preferred'
+livecrawlTimeout?: number
+subpages?: number       // 1-10
+subpageTarget?: string[]
+```
+
+---
+
+## Configuration Options
+
+### URL/CLI Parameters
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `enabled` | string | Comma-separated list of tools to enable |
+| `disabled` | string | Comma-separated list of tools to disable (optional, for display) |
+| `tools` | string | [LEGACY] Alias for enabled, backwards compatible |
+| `enabledTools` | string | [LEGACY] Alias for enabled, backwards compatible |
+| `debug` | boolean | Enable debug logging |
+
+### Environment Variables
+
+| Variable | Description |
+|----------|-------------|
+| `EXA_API_KEY` | Exa AI API key |
+
+### API Key Methods
+
+```bash
+# Environment variable (recommended)
+export EXA_API_KEY="your-api-key"
+
+# HTTP header
+headers: { "x-api-key": "your-api-key" }
+
+# Query parameter (easy sharing)
+?exaApiKey=your-api-key
+```
+
+---
+
+## Examples
+
+### Category-Filtered Search
+
+Search only news articles from the last week:
+
+```typescript
+// Using web_search_advanced
+{
+  query: "AI regulations",
+  category: "news",
+  startPublishedDate: "2024-01-01",
+  numResults: 10
+}
+```
+
+### Domain-Restricted Research
+
+Search only from trusted sources:
+
+```typescript
+{
+  query: "climate change research",
+  includeDomains: ["nature.com", "science.org", "arxiv.org"],
+  category: "research paper"
+}
+```
+
+### Find Competitors
+
+Find similar companies to a given website:
+
+```typescript
+// Using find_similar_exa
+{
+  url: "https://example-startup.com",
+  category: "company",
+  numResults: 20
+}
+```
+
+### Q&A with Citations
+
+Get a factual answer with sources:
+
+```typescript
+// Using answer_exa
+{
+  query: "What is the current market cap of Apple?",
+  category: "financial report",
+  numResults: 5
+}
+```
+
+### Batch Content Extraction
+
+Crawl multiple URLs with summaries:
+
+```typescript
+// Using crawl_urls_exa
+{
+  urls: [
+    "https://example.com/article1",
+    "https://example.com/article2"
+  ],
+  enableSummary: true,
+  enableHighlights: true,
+  highlightsPerUrl: 3
+}
+```
+
+---
+
+## Version History
+
+- **3.2.0** - Added `web_search_advanced`, `find_similar_exa`, `answer_exa`, `crawl_urls_exa`. New `enabled`/`disabled` URL pattern.
+- **3.1.x** - Core tools: web_search, code_context, deep_search, company_research, linkedin, crawling, deep_researcher

--- a/package-lock.json
+++ b/package-lock.json
@@ -850,7 +850,6 @@
       "version": "20.17.8",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.19.2"
       }
@@ -1547,7 +1546,6 @@
     "node_modules/express": {
       "version": "5.1.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.0",
@@ -3337,7 +3335,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "exa-mcp-server",
-  "version": "3.1.3",
+  "version": "3.2.0",
   "description": "A Model Context Protocol server with Exa for web search and web crawling. Provides real-time web searches with configurable tool selection, allowing users to enable or disable specific search capabilities. Supports customizable result counts, live crawling options, and returns content from the most relevant websites.",
   "mcpName": "io.github.exa-labs/exa-mcp-server",
   "type": "module",

--- a/src/tools/answer.ts
+++ b/src/tools/answer.ts
@@ -1,0 +1,160 @@
+import { z } from "zod";
+import axios from "axios";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { API_CONFIG } from "./config.js";
+import { createRequestLogger } from "../utils/logger.js";
+import { checkpoint } from "agnost";
+
+interface AnswerResponse {
+  requestId: string;
+  answer: string;
+  citations?: Array<{
+    id: string;
+    url: string;
+    title: string;
+    snippet?: string;
+    publishedDate?: string;
+  }>;
+}
+
+export function registerAnswerTool(server: McpServer, config?: { exaApiKey?: string }): void {
+  server.tool(
+    "answer_exa",
+    "Get a direct answer to a question with citations from the web - Exa searches the web and synthesizes an answer with source citations. Ideal for factual questions, research queries, or when you need verified information with sources.",
+    {
+      query: z.string().describe("Question or query to answer"),
+      numResults: z.number().optional().describe("Number of sources to use for answering (1-20, default: 5)"),
+      includeDomains: z.array(z.string()).optional().describe("Only use sources from these domains"),
+      excludeDomains: z.array(z.string()).optional().describe("Exclude sources from these domains"),
+      startPublishedDate: z.string().optional().describe("Only use sources published after this date (ISO 8601: YYYY-MM-DD)"),
+      endPublishedDate: z.string().optional().describe("Only use sources published before this date (ISO 8601: YYYY-MM-DD)"),
+      category: z.enum(['company', 'research paper', 'news', 'pdf', 'github', 'tweet', 'personal site', 'people', 'financial report']).optional().describe("Filter sources to a specific category"),
+    },
+    {
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true
+    },
+    async (params) => {
+      const requestId = `answer_exa-${Date.now()}-${Math.random().toString(36).substring(2, 7)}`;
+      const logger = createRequestLogger(requestId, 'answer_exa');
+
+      logger.start(params.query);
+
+      try {
+        const axiosInstance = axios.create({
+          baseURL: API_CONFIG.BASE_URL,
+          headers: {
+            'accept': 'application/json',
+            'content-type': 'application/json',
+            'x-api-key': config?.exaApiKey || process.env.EXA_API_KEY || '',
+            'x-exa-integration': 'answer-mcp'
+          },
+          timeout: 60000 // Longer timeout for answer generation
+        });
+
+        const answerRequest: Record<string, unknown> = {
+          query: params.query,
+          numResults: params.numResults || 5,
+        };
+
+        if (params.includeDomains && params.includeDomains.length > 0) {
+          answerRequest.includeDomains = params.includeDomains;
+        }
+
+        if (params.excludeDomains && params.excludeDomains.length > 0) {
+          answerRequest.excludeDomains = params.excludeDomains;
+        }
+
+        if (params.startPublishedDate) {
+          answerRequest.startPublishedDate = params.startPublishedDate;
+        }
+
+        if (params.endPublishedDate) {
+          answerRequest.endPublishedDate = params.endPublishedDate;
+        }
+
+        if (params.category) {
+          answerRequest.category = params.category;
+        }
+
+        checkpoint('answer_request_prepared');
+        logger.log("Sending answer request to Exa API");
+
+        const response = await axiosInstance.post<AnswerResponse>(
+          API_CONFIG.ENDPOINTS.ANSWER,
+          answerRequest,
+          { timeout: 60000 }
+        );
+
+        checkpoint('answer_response_received');
+        logger.log("Received response from Exa API");
+
+        if (!response.data || !response.data.answer) {
+          logger.log("Warning: No answer in response from Exa API");
+          checkpoint('answer_complete');
+          return {
+            content: [{
+              type: "text" as const,
+              text: "Unable to generate an answer for this query. Please try rephrasing your question."
+            }]
+          };
+        }
+
+        // Format response with answer and citations
+        let resultText = `## Answer\n\n${response.data.answer}\n`;
+
+        if (response.data.citations && response.data.citations.length > 0) {
+          resultText += `\n## Sources\n\n`;
+          response.data.citations.forEach((citation, index) => {
+            resultText += `${index + 1}. [${citation.title}](${citation.url})`;
+            if (citation.publishedDate) {
+              resultText += ` (${citation.publishedDate})`;
+            }
+            resultText += '\n';
+            if (citation.snippet) {
+              resultText += `   > ${citation.snippet}\n`;
+            }
+          });
+        }
+
+        logger.log(`Response prepared with ${resultText.length} characters`);
+
+        const result = {
+          content: [{
+            type: "text" as const,
+            text: resultText
+          }]
+        };
+
+        checkpoint('answer_complete');
+        logger.complete();
+        return result;
+      } catch (error) {
+        logger.error(error);
+
+        if (axios.isAxiosError(error)) {
+          const statusCode = error.response?.status || 'unknown';
+          const errorMessage = error.response?.data?.message || error.message;
+
+          logger.log(`Axios error (${statusCode}): ${errorMessage}`);
+          return {
+            content: [{
+              type: "text" as const,
+              text: `Answer error (${statusCode}): ${errorMessage}`
+            }],
+            isError: true,
+          };
+        }
+
+        return {
+          content: [{
+            type: "text" as const,
+            text: `Answer error: ${error instanceof Error ? error.message : String(error)}`
+          }],
+          isError: true,
+        };
+      }
+    }
+  );
+}

--- a/src/tools/config.ts
+++ b/src/tools/config.ts
@@ -3,6 +3,9 @@ export const API_CONFIG = {
   BASE_URL: 'https://api.exa.ai',
   ENDPOINTS: {
     SEARCH: '/search',
+    FIND_SIMILAR: '/findSimilar',
+    ANSWER: '/answer',
+    CONTENTS: '/contents',
     RESEARCH_TASKS: '/research/v0/tasks',
     CONTEXT: '/context'
   },

--- a/src/tools/crawlUrls.ts
+++ b/src/tools/crawlUrls.ts
@@ -1,0 +1,189 @@
+import { z } from "zod";
+import axios from "axios";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { API_CONFIG } from "./config.js";
+import { createRequestLogger } from "../utils/logger.js";
+import { checkpoint } from "agnost";
+
+interface CrawlResult {
+  id: string;
+  url: string;
+  title?: string;
+  author?: string;
+  publishedDate?: string;
+  text?: string;
+  summary?: string;
+  highlights?: string[];
+  image?: string;
+  favicon?: string;
+}
+
+interface CrawlResponse {
+  requestId: string;
+  results: CrawlResult[];
+}
+
+export function registerCrawlUrlsTool(server: McpServer, config?: { exaApiKey?: string }): void {
+  server.tool(
+    "crawl_urls_exa",
+    "Crawl and extract content from one or more URLs - retrieves full text, metadata, summaries, and highlights. Supports batch URL processing and advanced content extraction options.",
+    {
+      urls: z.array(z.string()).describe("URLs to crawl (can be a single URL or multiple)"),
+      textMaxCharacters: z.number().optional().describe("Max characters for text extraction per URL"),
+      enableSummary: z.boolean().optional().describe("Generate a summary for each page"),
+      summaryQuery: z.string().optional().describe("Focus query for summary generation"),
+      enableHighlights: z.boolean().optional().describe("Extract key highlights from each page"),
+      highlightsNumSentences: z.number().optional().describe("Number of sentences per highlight"),
+      highlightsPerUrl: z.number().optional().describe("Number of highlights per URL"),
+      highlightsQuery: z.string().optional().describe("Query for highlight relevance"),
+      livecrawl: z.enum(['never', 'fallback', 'always', 'preferred']).optional().describe("Live crawl mode - 'never': only cached, 'fallback': cached then live, 'always': always live, 'preferred': prefer live (default: 'preferred')"),
+      livecrawlTimeout: z.number().optional().describe("Timeout for live crawl in milliseconds"),
+      subpages: z.number().optional().describe("Number of subpages to crawl from each URL (1-10)"),
+      subpageTarget: z.array(z.string()).optional().describe("Keywords to target when selecting subpages"),
+    },
+    {
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true
+    },
+    async (params) => {
+      const requestId = `crawl_urls_exa-${Date.now()}-${Math.random().toString(36).substring(2, 7)}`;
+      const logger = createRequestLogger(requestId, 'crawl_urls_exa');
+
+      logger.start(`Crawling ${params.urls.length} URL(s)`);
+
+      try {
+        const axiosInstance = axios.create({
+          baseURL: API_CONFIG.BASE_URL,
+          headers: {
+            'accept': 'application/json',
+            'content-type': 'application/json',
+            'x-api-key': config?.exaApiKey || process.env.EXA_API_KEY || '',
+            'x-exa-integration': 'crawl-urls-mcp'
+          },
+          timeout: params.livecrawlTimeout || 60000
+        });
+
+        // Build contents configuration
+        const contents: Record<string, unknown> = {
+          text: params.textMaxCharacters ? { maxCharacters: params.textMaxCharacters } : true,
+          livecrawl: params.livecrawl || 'preferred',
+        };
+
+        if (params.livecrawlTimeout) {
+          contents.livecrawlTimeout = params.livecrawlTimeout;
+        }
+
+        if (params.enableSummary) {
+          contents.summary = params.summaryQuery ? { query: params.summaryQuery } : true;
+        }
+
+        if (params.enableHighlights) {
+          contents.highlights = {
+            numSentences: params.highlightsNumSentences,
+            highlightsPerUrl: params.highlightsPerUrl,
+            query: params.highlightsQuery,
+          };
+        }
+
+        if (params.subpages) {
+          contents.subpages = params.subpages;
+        }
+
+        if (params.subpageTarget) {
+          contents.subpageTarget = params.subpageTarget;
+        }
+
+        const crawlRequest = {
+          ids: params.urls,
+          contents,
+        };
+
+        checkpoint('crawl_urls_request_prepared');
+        logger.log("Sending crawl request to Exa API");
+
+        const response = await axiosInstance.post<CrawlResponse>(
+          API_CONFIG.ENDPOINTS.CONTENTS,
+          crawlRequest,
+          { timeout: params.livecrawlTimeout || 60000 }
+        );
+
+        checkpoint('crawl_urls_response_received');
+        logger.log("Received response from Exa API");
+
+        if (!response.data || !response.data.results || response.data.results.length === 0) {
+          logger.log("Warning: No content found in response");
+          checkpoint('crawl_urls_complete');
+          return {
+            content: [{
+              type: "text" as const,
+              text: "No content found for the provided URL(s)."
+            }]
+          };
+        }
+
+        // Format results
+        let resultText = response.data.results.map((result, index) => {
+          let entry = `## ${index + 1}. ${result.title || 'Untitled'}\n`;
+          entry += `URL: ${result.url}\n`;
+          if (result.author) entry += `Author: ${result.author}\n`;
+          if (result.publishedDate) entry += `Published: ${result.publishedDate}\n`;
+
+          if (result.summary) {
+            entry += `\n### Summary\n${result.summary}\n`;
+          }
+
+          if (result.highlights && result.highlights.length > 0) {
+            entry += `\n### Highlights\n`;
+            result.highlights.forEach((highlight, i) => {
+              entry += `- ${highlight}\n`;
+            });
+          }
+
+          if (result.text) {
+            entry += `\n### Content\n${result.text}\n`;
+          }
+
+          return entry;
+        }).join('\n---\n\n');
+
+        logger.log(`Response prepared with ${resultText.length} characters`);
+
+        const result = {
+          content: [{
+            type: "text" as const,
+            text: resultText
+          }]
+        };
+
+        checkpoint('crawl_urls_complete');
+        logger.complete();
+        return result;
+      } catch (error) {
+        logger.error(error);
+
+        if (axios.isAxiosError(error)) {
+          const statusCode = error.response?.status || 'unknown';
+          const errorMessage = error.response?.data?.message || error.message;
+
+          logger.log(`Axios error (${statusCode}): ${errorMessage}`);
+          return {
+            content: [{
+              type: "text" as const,
+              text: `Crawl URLs error (${statusCode}): ${errorMessage}`
+            }],
+            isError: true,
+          };
+        }
+
+        return {
+          content: [{
+            type: "text" as const,
+            text: `Crawl URLs error: ${error instanceof Error ? error.message : String(error)}`
+          }],
+          isError: true,
+        };
+      }
+    }
+  );
+}

--- a/src/tools/findSimilar.ts
+++ b/src/tools/findSimilar.ts
@@ -1,0 +1,157 @@
+import { z } from "zod";
+import axios from "axios";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { API_CONFIG } from "./config.js";
+import { ExaSearchResponse } from "../types.js";
+import { createRequestLogger } from "../utils/logger.js";
+import { checkpoint } from "agnost";
+
+export function registerFindSimilarTool(server: McpServer, config?: { exaApiKey?: string }): void {
+  server.tool(
+    "find_similar_exa",
+    "Find web pages similar to a given URL - useful for discovering related content, competitors, similar articles, or pages with comparable topics and styles.",
+    {
+      url: z.string().describe("URL to find similar content for"),
+      numResults: z.number().optional().describe("Number of similar results to return (1-100, default: 10)"),
+      includeDomains: z.array(z.string()).optional().describe("Only include results from these domains"),
+      excludeDomains: z.array(z.string()).optional().describe("Exclude results from these domains"),
+      startPublishedDate: z.string().optional().describe("Only include results published after this date (ISO 8601: YYYY-MM-DD)"),
+      endPublishedDate: z.string().optional().describe("Only include results published before this date (ISO 8601: YYYY-MM-DD)"),
+      category: z.enum(['company', 'research paper', 'news', 'pdf', 'github', 'tweet', 'personal site', 'people', 'financial report']).optional().describe("Filter results to a specific category"),
+      excludeSourceDomain: z.boolean().optional().describe("Exclude the source URL's domain from results (default: true)"),
+      textMaxCharacters: z.number().optional().describe("Max characters for text extraction per result"),
+      contextMaxCharacters: z.number().optional().describe("Max characters for context string (default: 10000)"),
+    },
+    {
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true
+    },
+    async (params) => {
+      const requestId = `find_similar_exa-${Date.now()}-${Math.random().toString(36).substring(2, 7)}`;
+      const logger = createRequestLogger(requestId, 'find_similar_exa');
+
+      logger.start(params.url);
+
+      try {
+        const axiosInstance = axios.create({
+          baseURL: API_CONFIG.BASE_URL,
+          headers: {
+            'accept': 'application/json',
+            'content-type': 'application/json',
+            'x-api-key': config?.exaApiKey || process.env.EXA_API_KEY || '',
+            'x-exa-integration': 'find-similar-mcp'
+          },
+          timeout: 30000
+        });
+
+        const findSimilarRequest: Record<string, unknown> = {
+          url: params.url,
+          numResults: params.numResults || 10,
+          excludeSourceDomain: params.excludeSourceDomain !== false, // default true
+          contents: {
+            text: params.textMaxCharacters ? { maxCharacters: params.textMaxCharacters } : true,
+            context: { maxCharacters: params.contextMaxCharacters || 10000 },
+          }
+        };
+
+        if (params.includeDomains && params.includeDomains.length > 0) {
+          findSimilarRequest.includeDomains = params.includeDomains;
+        }
+
+        if (params.excludeDomains && params.excludeDomains.length > 0) {
+          findSimilarRequest.excludeDomains = params.excludeDomains;
+        }
+
+        if (params.startPublishedDate) {
+          findSimilarRequest.startPublishedDate = params.startPublishedDate;
+        }
+
+        if (params.endPublishedDate) {
+          findSimilarRequest.endPublishedDate = params.endPublishedDate;
+        }
+
+        if (params.category) {
+          findSimilarRequest.category = params.category;
+        }
+
+        checkpoint('find_similar_request_prepared');
+        logger.log("Sending findSimilar request to Exa API");
+
+        const response = await axiosInstance.post<ExaSearchResponse>(
+          API_CONFIG.ENDPOINTS.FIND_SIMILAR,
+          findSimilarRequest,
+          { timeout: 30000 }
+        );
+
+        checkpoint('find_similar_response_received');
+        logger.log("Received response from Exa API");
+
+        if (!response.data) {
+          logger.log("Warning: Empty response from Exa API");
+          checkpoint('find_similar_complete');
+          return {
+            content: [{
+              type: "text" as const,
+              text: "No similar pages found for the provided URL."
+            }]
+          };
+        }
+
+        let resultText = '';
+
+        if (response.data.context) {
+          resultText = response.data.context;
+        } else if (response.data.results && response.data.results.length > 0) {
+          resultText = response.data.results.map((result, index) => {
+            let entry = `## ${index + 1}. ${result.title || 'Untitled'}\n`;
+            entry += `URL: ${result.url}\n`;
+            if (result.score) entry += `Similarity Score: ${result.score.toFixed(3)}\n`;
+            if (result.publishedDate) entry += `Published: ${result.publishedDate}\n`;
+            if (result.text) entry += `\n${result.text}\n`;
+            return entry;
+          }).join('\n---\n');
+        } else {
+          resultText = "No similar pages found.";
+        }
+
+        logger.log(`Response prepared with ${resultText.length} characters`);
+
+        const result = {
+          content: [{
+            type: "text" as const,
+            text: resultText
+          }]
+        };
+
+        checkpoint('find_similar_complete');
+        logger.complete();
+        return result;
+      } catch (error) {
+        logger.error(error);
+
+        if (axios.isAxiosError(error)) {
+          const statusCode = error.response?.status || 'unknown';
+          const errorMessage = error.response?.data?.message || error.message;
+
+          logger.log(`Axios error (${statusCode}): ${errorMessage}`);
+          return {
+            content: [{
+              type: "text" as const,
+              text: `Find similar error (${statusCode}): ${errorMessage}`
+            }],
+            isError: true,
+          };
+        }
+
+        return {
+          content: [{
+            type: "text" as const,
+            text: `Find similar error: ${error instanceof Error ? error.message : String(error)}`
+          }],
+          isError: true,
+        };
+      }
+    }
+  );
+}

--- a/src/tools/webSearchAdvanced.ts
+++ b/src/tools/webSearchAdvanced.ts
@@ -1,0 +1,273 @@
+import { z } from "zod";
+import axios from "axios";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { API_CONFIG } from "./config.js";
+import { ExaAdvancedSearchRequest, ExaSearchResponse } from "../types.js";
+import { createRequestLogger } from "../utils/logger.js";
+import { checkpoint } from "agnost"
+
+export function registerWebSearchAdvancedTool(server: McpServer, config?: { exaApiKey?: string }): void {
+  server.tool(
+    "web_search_advanced",
+    "Advanced web search with full Exa API control - use this when you need precise control over search parameters like category filters, domain restrictions, date ranges, content extraction options, highlights, summaries, and subpage crawling. For simple searches, use web_search_exa instead.",
+    {
+      // Core parameters
+      query: z.string().describe("Search query - can be a question, statement, or keywords"),
+      numResults: z.number().optional().describe("Number of results (1-100, default: 10)"),
+      type: z.enum(['auto', 'fast', 'deep', 'neural']).optional().describe("Search type - 'auto': balanced (default), 'fast': quick results, 'deep': comprehensive, 'neural': semantic search"),
+
+      // Category filtering
+      category: z.enum(['company', 'research paper', 'news', 'pdf', 'github', 'tweet', 'personal site', 'people', 'financial report']).optional().describe("Filter results to a specific category"),
+
+      // Domain filtering
+      includeDomains: z.array(z.string()).optional().describe("Only include results from these domains (e.g., ['arxiv.org', 'github.com'])"),
+      excludeDomains: z.array(z.string()).optional().describe("Exclude results from these domains"),
+
+      // Date filtering
+      startPublishedDate: z.string().optional().describe("Only include results published after this date (ISO 8601: YYYY-MM-DD)"),
+      endPublishedDate: z.string().optional().describe("Only include results published before this date (ISO 8601: YYYY-MM-DD)"),
+      startCrawlDate: z.string().optional().describe("Only include results crawled after this date (ISO 8601: YYYY-MM-DD)"),
+      endCrawlDate: z.string().optional().describe("Only include results crawled before this date (ISO 8601: YYYY-MM-DD)"),
+
+      // Content filtering
+      includeText: z.array(z.string()).optional().describe("Only include results containing ALL of these text strings"),
+      excludeText: z.array(z.string()).optional().describe("Exclude results containing ANY of these text strings"),
+
+      // Geo-targeting
+      userLocation: z.string().optional().describe("ISO country code for geo-targeted results (e.g., 'US', 'GB', 'DE')"),
+
+      // Content moderation
+      moderation: z.boolean().optional().describe("Filter out unsafe/inappropriate content"),
+
+      // Additional queries for expanded search
+      additionalQueries: z.array(z.string()).optional().describe("Additional query variations to expand search coverage"),
+
+      // Content extraction options
+      textMaxCharacters: z.number().optional().describe("Max characters for text extraction per result"),
+      contextMaxCharacters: z.number().optional().describe("Max characters for context string (default: 10000)"),
+
+      // Summary options
+      enableSummary: z.boolean().optional().describe("Enable summary generation for results"),
+      summaryQuery: z.string().optional().describe("Focus query for summary generation"),
+
+      // Highlights options
+      enableHighlights: z.boolean().optional().describe("Enable highlights extraction"),
+      highlightsNumSentences: z.number().optional().describe("Number of sentences per highlight"),
+      highlightsPerUrl: z.number().optional().describe("Number of highlights per URL"),
+      highlightsQuery: z.string().optional().describe("Query for highlight relevance"),
+
+      // Livecrawl options
+      livecrawl: z.enum(['never', 'fallback', 'always', 'preferred']).optional().describe("Live crawl mode - 'never': only cached, 'fallback': cached then live, 'always': always live, 'preferred': prefer live (default: 'fallback')"),
+      livecrawlTimeout: z.number().optional().describe("Timeout for live crawl in milliseconds"),
+
+      // Subpage crawling
+      subpages: z.number().optional().describe("Number of subpages to crawl from each result (1-10)"),
+      subpageTarget: z.array(z.string()).optional().describe("Keywords to target when selecting subpages"),
+
+      // Extras
+      extractLinks: z.number().optional().describe("Number of links to extract per page"),
+      extractImages: z.number().optional().describe("Number of images to extract per result"),
+    },
+    {
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true
+    },
+    async (params) => {
+      const requestId = `web_search_advanced-${Date.now()}-${Math.random().toString(36).substring(2, 7)}`;
+      const logger = createRequestLogger(requestId, 'web_search_advanced');
+
+      logger.start(params.query);
+
+      try {
+        const axiosInstance = axios.create({
+          baseURL: API_CONFIG.BASE_URL,
+          headers: {
+            'accept': 'application/json',
+            'content-type': 'application/json',
+            'x-api-key': config?.exaApiKey || process.env.EXA_API_KEY || '',
+            'x-exa-integration': 'web-search-advanced-mcp'
+          },
+          timeout: params.livecrawlTimeout || 30000
+        });
+
+        // Build the contents object
+        const contents: ExaAdvancedSearchRequest['contents'] = {
+          text: params.textMaxCharacters ? { maxCharacters: params.textMaxCharacters } : true,
+          context: { maxCharacters: params.contextMaxCharacters || 10000 },
+          livecrawl: params.livecrawl || 'fallback',
+        };
+
+        // Add optional content options
+        if (params.livecrawlTimeout) {
+          contents.livecrawlTimeout = params.livecrawlTimeout;
+        }
+
+        if (params.enableSummary) {
+          contents.summary = params.summaryQuery ? { query: params.summaryQuery } : true;
+        }
+
+        if (params.enableHighlights) {
+          contents.highlights = {
+            numSentences: params.highlightsNumSentences,
+            highlightsPerUrl: params.highlightsPerUrl,
+            query: params.highlightsQuery,
+          };
+        }
+
+        if (params.subpages) {
+          contents.subpages = params.subpages;
+        }
+
+        if (params.subpageTarget) {
+          contents.subpageTarget = params.subpageTarget;
+        }
+
+        if (params.extractLinks) {
+          contents.extractLinks = params.extractLinks;
+        }
+
+        if (params.extractImages) {
+          contents.extractImages = params.extractImages;
+        }
+
+        // Build the search request
+        const searchRequest: ExaAdvancedSearchRequest = {
+          query: params.query,
+          type: params.type || 'auto',
+          numResults: params.numResults || 10,
+          contents,
+        };
+
+        // Add optional filters
+        if (params.category) {
+          searchRequest.category = params.category;
+        }
+
+        if (params.includeDomains && params.includeDomains.length > 0) {
+          searchRequest.includeDomains = params.includeDomains;
+        }
+
+        if (params.excludeDomains && params.excludeDomains.length > 0) {
+          searchRequest.excludeDomains = params.excludeDomains;
+        }
+
+        if (params.startPublishedDate) {
+          searchRequest.startPublishedDate = params.startPublishedDate;
+        }
+
+        if (params.endPublishedDate) {
+          searchRequest.endPublishedDate = params.endPublishedDate;
+        }
+
+        if (params.startCrawlDate) {
+          searchRequest.startCrawlDate = params.startCrawlDate;
+        }
+
+        if (params.endCrawlDate) {
+          searchRequest.endCrawlDate = params.endCrawlDate;
+        }
+
+        if (params.includeText && params.includeText.length > 0) {
+          searchRequest.includeText = params.includeText;
+        }
+
+        if (params.excludeText && params.excludeText.length > 0) {
+          searchRequest.excludeText = params.excludeText;
+        }
+
+        if (params.userLocation) {
+          searchRequest.userLocation = params.userLocation;
+        }
+
+        if (params.moderation !== undefined) {
+          searchRequest.moderation = params.moderation;
+        }
+
+        if (params.additionalQueries && params.additionalQueries.length > 0) {
+          searchRequest.additionalQueries = params.additionalQueries;
+        }
+
+        checkpoint('web_search_advanced_request_prepared');
+        logger.log("Sending advanced search request to Exa API");
+
+        const response = await axiosInstance.post<ExaSearchResponse>(
+          API_CONFIG.ENDPOINTS.SEARCH,
+          searchRequest,
+          { timeout: params.livecrawlTimeout || 30000 }
+        );
+
+        checkpoint('exa_advanced_search_response_received');
+        logger.log("Received response from Exa API");
+
+        if (!response.data) {
+          logger.log("Warning: Empty response from Exa API");
+          checkpoint('web_search_advanced_complete');
+          return {
+            content: [{
+              type: "text" as const,
+              text: "No search results found. Please try a different query or adjust your filters."
+            }]
+          };
+        }
+
+        // Build a comprehensive response
+        let resultText = '';
+
+        if (response.data.context) {
+          resultText = response.data.context;
+        } else if (response.data.results && response.data.results.length > 0) {
+          // Format individual results if context not available
+          resultText = response.data.results.map((result, index) => {
+            let entry = `## ${index + 1}. ${result.title || 'Untitled'}\n`;
+            entry += `URL: ${result.url}\n`;
+            if (result.publishedDate) entry += `Published: ${result.publishedDate}\n`;
+            if (result.author) entry += `Author: ${result.author}\n`;
+            if (result.summary) entry += `\nSummary: ${result.summary}\n`;
+            if (result.text) entry += `\n${result.text}\n`;
+            return entry;
+          }).join('\n---\n');
+        } else {
+          resultText = "No results found for the given query and filters.";
+        }
+
+        logger.log(`Response prepared with ${resultText.length} characters`);
+
+        const result = {
+          content: [{
+            type: "text" as const,
+            text: resultText
+          }]
+        };
+
+        checkpoint('web_search_advanced_complete');
+        logger.complete();
+        return result;
+      } catch (error) {
+        logger.error(error);
+
+        if (axios.isAxiosError(error)) {
+          const statusCode = error.response?.status || 'unknown';
+          const errorMessage = error.response?.data?.message || error.message;
+
+          logger.log(`Axios error (${statusCode}): ${errorMessage}`);
+          return {
+            content: [{
+              type: "text" as const,
+              text: `Advanced search error (${statusCode}): ${errorMessage}`
+            }],
+            isError: true,
+          };
+        }
+
+        return {
+          content: [{
+            type: "text" as const,
+            text: `Advanced search error: ${error instanceof Error ? error.message : String(error)}`
+          }],
+          isError: true,
+        };
+      }
+    }
+  );
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,7 +1,7 @@
 // Exa API Types
 export interface ExaSearchRequest {
   query: string;
-  type: 'auto' | 'fast' | 'deep';
+  type: 'auto' | 'fast' | 'deep' | 'neural';
   category?: string;
   includeDomains?: string[];
   excludeDomains?: string[];
@@ -22,6 +22,64 @@ export interface ExaSearchRequest {
     livecrawl?: 'fallback' | 'preferred';
     subpages?: number;
     subpageTarget?: string[];
+  };
+}
+
+// Advanced Search Request - Full Exa API surface
+export interface ExaAdvancedSearchRequest {
+  query: string;
+  type?: 'auto' | 'fast' | 'deep' | 'neural';
+  numResults?: number;
+
+  // Category filtering
+  category?: 'company' | 'research paper' | 'news' | 'pdf' | 'github' | 'tweet' | 'personal site' | 'people' | 'financial report';
+
+  // Domain filtering
+  includeDomains?: string[];
+  excludeDomains?: string[];
+
+  // Date filtering
+  startPublishedDate?: string;
+  endPublishedDate?: string;
+  startCrawlDate?: string;
+  endCrawlDate?: string;
+
+  // Content filtering
+  includeText?: string[];
+  excludeText?: string[];
+
+  // Geo-targeting
+  userLocation?: string;
+
+  // Content moderation
+  moderation?: boolean;
+
+  // Additional queries for expanded search
+  additionalQueries?: string[];
+
+  // Contents configuration
+  contents: {
+    text?: {
+      maxCharacters?: number;
+    } | boolean;
+    context?: {
+      maxCharacters?: number;
+    } | boolean;
+    summary?: {
+      query?: string;
+      schema?: object;
+    } | boolean;
+    highlights?: {
+      numSentences?: number;
+      highlightsPerUrl?: number;
+      query?: string;
+    } | boolean;
+    livecrawl?: 'never' | 'fallback' | 'always' | 'preferred';
+    livecrawlTimeout?: number;
+    subpages?: number;
+    subpageTarget?: string[];
+    extractLinks?: number;
+    extractImages?: number;
   };
 }
 


### PR DESCRIPTION
## Summary

This PR introduces a "Skills Architecture" for the Exa MCP server - making it easier for users to leverage Exa's full power through smart defaults, self-documenting configuration, and workflow-specific guidance.

## The Problem We Were Solving

1. **Users don't know which tools to enable** for their use case
2. **Simple search doesn't expose Exa's full power** (categories, domain filtering, highlights, summaries, subpages)
3. **No guidance on HOW to combine tools** for real workflows (company research, GTM, academic research)

## Design Philosophy

**"Simple MCP + Smart Docs + Full Power"**

- **MCP** = Zero config default, all tools available when needed
- **Docs** = Comprehensive reference that humans copy from and LLMs parse
- **Skills** = Optional workflow guides that teach WHEN and HOW to use powerful params

**No modes.** One install, everything works. Skills teach usage patterns.

---

## Key Design Decisions

### 1. Two Search Tools (Same Endpoint)

We needed TWO tools calling the SAME `/search` endpoint:
- **`web_search_exa`** - Simple params for everyday use (existing)
- **`web_search_advanced`** - Full Exa API surface for building skills (NEW)

**Why not just add params to the existing tool?**
- Keeps simple tool simple (3 params vs 25+)
- Advanced users get full control without cluttering basic experience
- Skills can reference the advanced tool specifically

**Naming research:** Consulted multiple AI models. Chose `web_search_advanced` to keep `web_search_` prefix consistent - the `_advanced` suffix clearly signals "more options."

### 2. Self-Documenting URL Pattern

Instead of hidden config, the URL itself shows what's ON and OFF:

```bash
# NEW pattern (preferred)
--enabled=web_search_exa,get_code_context_exa

# LEGACY pattern (still works)
--tools=web_search_exa,get_code_context_exa
```

Server echoes full state on startup:
```
Exa MCP loaded - ENABLED: web_search_exa,get_code_context_exa | DISABLED: web_search_advanced,...
```

**Benefits:**
- LLM reads URL → knows exactly what's available
- Human reads URL → knows what they're getting  
- Want more tools? → Just edit the URL
- Full transparency, no hidden config

### 3. Skills Instead of Modes

We considered "modes" (research mode, GTM mode) but rejected it.

**Skills are better because:**
1. MCP always has full capability - skills just teach patterns
2. Users can mix and match - not locked into one mode
3. Skills are documentation that Claude reads contextually
4. No code changes needed to add new workflows

---

## What's New

### New Tools (4)

| Tool | Endpoint | Purpose |
|------|----------|---------|
| `web_search_advanced` | /search | Full API: categories, domains, dates, highlights, summaries, subpages |
| `find_similar_exa` | /findSimilar | Find pages similar to a URL |
| `answer_exa` | /answer | Direct Q&A with citations |
| `crawl_urls_exa` | /contents | Batch URL crawling with extraction options |

### Smart Docs (`docs/install.md`)

- Platform-specific install configs
- Configuration presets (Basic, Power User, Company Research, GTM, Full Power)
- Complete parameter reference
- Example usage patterns

### Claude Code Skills (5)

| Skill | Use Case |
|-------|----------|
| `exa-company-research` | Company intel, competitors, financials |
| `exa-people-research` | LinkedIn + web for people research |
| `exa-gtm` | Sales prospecting, pre-call research |
| `exa-research-paper` | Academic literature review |
| `exa-web-chunker` | Content extraction, documentation harvesting |

---

## Key Insight

The power isn't in having more tools - it's in knowing WHEN to use which params:
- `category: "company"` vs `category: "research paper"` 
- `includeDomains` for trusted sources
- `enableHighlights` + `highlightsQuery` for scanning
- `subpages` for documentation sites

Skills encode this knowledge so Claude can apply it automatically.

---

## Test Plan

- [ ] Verify `--enabled=web_search_exa` only registers that tool
- [ ] Verify legacy `--tools=web_search_exa` still works
- [ ] Test `web_search_advanced` with category filters
- [ ] Test `find_similar_exa` endpoint
- [ ] Test `answer_exa` endpoint  
- [ ] Test `crawl_urls_exa` batch crawling
- [ ] Verify skills load in Claude Code

🤖 Generated with [Claude Code](https://claude.com/claude-code)