### PR TITLE
Fix tool names in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,9 +208,9 @@ The Exa MCP server includes powerful tools for developers and researchers:
 - **get_code_context_exa**: Search and get relevant code snippets, examples, and documentation from open source libraries, GitHub repositories, and programming frameworks. Perfect for finding up-to-date code documentation, implementation examples, API usage patterns, and best practices from real codebases.
 - **web_search_exa**: Performs real-time web searches with optimized results and content extraction.
 - **deep_search_exa**: Deep web search with smart query expansion and high-quality summaries for each result.
-- **company_research**: Comprehensive company research tool that crawls company websites to gather detailed information about businesses.
-- **crawling**: Extracts content from specific URLs, useful for reading articles, PDFs, or any web page when you have the exact URL.
-- **linkedin_search**: Search LinkedIn for companies and people using Exa AI. Simply include company names, person names, or specific LinkedIn URLs in your query.
+- **company_research_exa**: Comprehensive company research tool that crawls company websites to gather detailed information about businesses.
+- **crawling_exa**: Extracts content from specific URLs, useful for reading articles, PDFs, or any web page when you have the exact URL.
+- **linkedin_search_exa**: Search LinkedIn for companies and people using Exa AI. Simply include company names, person names, or specific LinkedIn URLs in your query.
 - **deep_researcher_start**: Start a smart AI researcher for complex questions. The AI will search the web, read many sources, and think deeply about your question to create a detailed research report.
 - **deep_researcher_check**: Check if your research is ready and get the results. Use this after starting a research task to see if it's done and get your comprehensive report.
 


### PR DESCRIPTION
## Summary
- Corrects tool name documentation to match actual tool IDs

## Problem
The tool descriptions in the README listed incorrect names without the `_exa` suffix:
- `company_research` → should be `company_research_exa`
- `crawling` → should be `crawling_exa`
- `linkedin_search` → should be `linkedin_search_exa`

This caused confusion when configuring the `tools=` parameter, as the documented names didn't match the actual tool IDs registered in `availableTools` (index.ts:37-46).

## Test plan
- [x] Verified tool IDs in source match updated documentation
- [x] Confirmed consistency with example configurations (lines 251, 273)

🤖 Generated with [Claude Code](https://claude.com/claude-code)