### PR TITLE
fix(company-research): use category instead of hardcoded includeDomains

### DIFF
--- a/src/tools/companyResearch.ts
+++ b/src/tools/companyResearch.ts
@@ -33,16 +33,13 @@ export function registerCompanyResearchTool(server: McpServer, config?: { exaApi
         });
 
         const searchRequest: ExaSearchRequest = {
-          query: `${companyName} company business corporation information news financial`,
+          query: `${companyName} company`,
           type: "auto",
-          numResults: numResults || API_CONFIG.DEFAULT_NUM_RESULTS,
+          numResults: numResults || 5,
+          category: "company",
           contents: {
-            text: {
-              maxCharacters: API_CONFIG.DEFAULT_MAX_CHARACTERS
-            },
-            livecrawl: 'preferred'
-          },
-          includeDomains: ["bloomberg.com", "reuters.com", "crunchbase.com", "sec.gov", "linkedin.com", "forbes.com", "businesswire.com", "prnewswire.com"]
+            text: true
+          }
         };
         
         logger.log("Sending request to Exa API for company research");


### PR DESCRIPTION
## Summary
- Removes hardcoded includeDomains list (bloomberg, reuters, crunchbase, sec.gov, linkedin, forbes, businesswire, prnewswire)
- Uses category: company instead, matching the behavior on main branch

## Problem
The vercel-mcp-host branch diverged from main and never received the update to use category: company. This caused the company research tool to only return results from news sources instead of searching across all company-related content.

## Test plan
- [ ] Deploy to vercel-mcp-host
- [ ] Test company research queries return diverse results (not just news sources)

🤖 Generated with [Claude Code](https://claude.com/claude-code)