### PR TITLE
[claude-skills]: add company researcher skill

### DIFF
--- a/claude-skills/company-researcher/company-research.md
+++ b/claude-skills/company-researcher/company-research.md
@@ -1,0 +1,68 @@
+---
+name: company-research
+description: Company research using Exa search. Finds company info, competitors, news, tweets, financials, LinkedIn profiles, builds company lists.
+triggers:
+  - company research
+  - competitor analysis
+  - market research
+  - find companies
+  - research company
+  - company intel
+requires_mcp: exa
+context: fork
+---
+
+# Company Research
+
+## Tool Restriction (Critical)
+
+ONLY use `web_search_advanced` from Exa. Do NOT use `web_search_exa` or any other Exa tools.
+
+## Token Isolation (Critical)
+
+Never run Exa searches in main context. Always spawn Task agents:
+- Agent runs Exa search internally
+- Agent processes results using LLM intelligence
+- Agent returns only distilled output (compact JSON or brief markdown)
+- Main context stays clean regardless of search volume
+
+## Dynamic Tuning
+
+No hardcoded numResults. Tune to user intent:
+- User says "a few" → 10-20
+- User says "comprehensive" → 50-100
+- User specifies number → match it
+- Ambiguous? Ask: "How many companies would you like?"
+
+## Query Variation
+
+Exa returns different results for different phrasings. For coverage:
+- Generate 2-3 query variations
+- Run in parallel
+- Merge and deduplicate
+
+## Categories
+
+Use appropriate Exa category:
+- company → homepages, gargantuan amount of metadata such as headcount,
+  location, funding, revenue
+- news → press coverage
+- tweet → social presence
+- people → LinkedIn profiles (public data)
+
+## LinkedIn
+
+Public LinkedIn via Exa: category "people", no other filters
+Auth-required LinkedIn → use Claude in Chrome browser fallback
+
+## Browser Fallback
+
+Auto-fallback to Claude in Chrome when:
+- Exa returns insufficient results
+- Content is auth-gated
+- Dynamic pages need JavaScript
+
+## Models
+
+- haiku: fast extraction (listing, discovery)
+- opus: synthesis, analysis, browser automation


### PR DESCRIPTION
## Summary

Adds a new `claude-skills/company-researcher/` folder with a company research skill definition for Claude. This skill provides guidance for using Exa's search capabilities for company research, competitor analysis, and market research tasks.

## Review & Testing Checklist for Human

- [ ] Verify the skill references the correct Exa tool name (`web_search_advanced` vs `web_search_exa` - the skill file says to use `web_search_advanced`)
- [ ] Confirm the skill file format/frontmatter matches Claude's expected skill schema

### Notes

Requested by: @nitya-ops
Link to Devin run: https://app.devin.ai/sessions/56ab750b56cd491dab47b7f517a0dc64