### PR TITLE
feat: add maxCharacters param for highlights, deprecate numSentences/highlightsPerUrl

### DIFF
--- a/src/tools/webSearchAdvanced.ts
+++ b/src/tools/webSearchAdvanced.ts
@@ -41,8 +41,9 @@ export function registerWebSearchAdvancedTool(server: McpServer, config?: { exaA
       summaryQuery: z.string().optional().describe("Focus query for summary generation"),
 
       enableHighlights: z.boolean().optional().describe("Enable highlights extraction"),
-      highlightsNumSentences: z.number().optional().describe("Number of sentences per highlight"),
-      highlightsPerUrl: z.number().optional().describe("Number of highlights per URL"),
+      highlightsMaxCharacters: z.number().optional().describe("Maximum total characters across all highlights per URL (default: 2000)"),
+      highlightsNumSentences: z.number().optional().describe("Deprecated: use highlightsMaxCharacters instead. Number of sentences per highlight"),
+      highlightsPerUrl: z.number().optional().describe("Deprecated: use highlightsMaxCharacters instead. Number of highlights per URL"),
       highlightsQuery: z.string().optional().describe("Query for highlight relevance"),
 
       livecrawl: z.enum(['never', 'fallback', 'always', 'preferred']).optional().describe("Live crawl mode - 'never': only cached, 'fallback': cached then live, 'always': always live, 'preferred': prefer live (default: 'fallback')"),
@@ -90,6 +91,7 @@ export function registerWebSearchAdvancedTool(server: McpServer, config?: { exaA
 
         if (params.enableHighlights) {
           contents.highlights = {
+            maxCharacters: params.highlightsMaxCharacters,
             numSentences: params.highlightsNumSentences,
             highlightsPerUrl: params.highlightsPerUrl,
             query: params.highlightsQuery,

--- a/src/types.ts
+++ b/src/types.ts
@@ -52,6 +52,7 @@ export interface ExaAdvancedSearchRequest {
       query?: string;
     } | boolean;
     highlights?: {
+      maxCharacters?: number;
       numSentences?: number;
       highlightsPerUrl?: number;
       query?: string;


### PR DESCRIPTION
## Summary

Adds the new `highlightsMaxCharacters` parameter to the `web_search_advanced_exa` tool and marks the legacy `highlightsNumSentences` and `highlightsPerUrl` parameters as deprecated. This aligns the MCP server with the updated Exa API highlights configuration.

Changes:
- Added `maxCharacters?: number` to the highlights interface in `types.ts`
- Added `highlightsMaxCharacters` parameter to the webSearchAdvanced tool schema
- Updated descriptions for `highlightsNumSentences` and `highlightsPerUrl` to indicate deprecation
- Wired up the new parameter in the request construction

## Review & Testing Checklist for Human

- [ ] Verify `maxCharacters` field name matches the Exa API spec exactly
- [ ] Test the `web_search_advanced_exa` tool with `highlightsMaxCharacters` parameter to confirm it's passed correctly to the API
- [ ] Verify old parameters (`highlightsNumSentences`, `highlightsPerUrl`) still work for backward compatibility

### Notes

This is part of a coordinated update across multiple repos (docs, exa-py, exa-js, exa-mcp-server) to add the new `maxCharacters` highlights parameter.

Link to Devin run: https://app.devin.ai/sessions/f82de373837142da8261ab1462c223eb
Requested by: @LiamHz