### PR TITLE
[experimental] add terminal auth tools / session tokens

### DIFF
--- a/api/mcp.ts
+++ b/api/mcp.ts
@@ -116,7 +116,10 @@ function createRateLimitResponse(retryAfterSeconds: number, reset: number): Resp
 function isRateLimitedMethod(body: string): boolean {
   try {
     const parsed = JSON.parse(body);
-    return parsed.method === 'tools/call';
+    if (parsed.method !== 'tools/call') return false;
+    const toolName = parsed.params?.name;
+    if (toolName === 'get_otp' || toolName === 'validate_otp') return false;
+    return true;
   } catch {
     return false;
   }

--- a/api/mcp.ts
+++ b/api/mcp.ts
@@ -3,7 +3,8 @@ process.env.AGNOST_LOG_LEVEL = 'error';
 import { createMcpHandler } from 'mcp-handler';
 import { initializeMcpServer } from '../src/mcp-handler.js';
 import { Ratelimit } from '@upstash/ratelimit';
-import { Redis } from '@upstash/redis';
+import { getRedisClient } from '../src/utils/redis.js';
+import { resolveSessionToken } from '../src/utils/session.js';
 
 /**
  * IP-based rate limiting configuration for free MCP users.
@@ -23,47 +24,38 @@ import { Redis } from '@upstash/redis';
 let qpsLimiter: Ratelimit | null = null;
 let dailyLimiter: Ratelimit | null = null;
 let rateLimitersInitialized = false;
-let redisClient: Redis | null = null;
 
 function initializeRateLimiters(): boolean {
   if (rateLimitersInitialized) {
     return qpsLimiter !== null;
   }
-  
+
   rateLimitersInitialized = true;
-  
-  // Support both Vercel KV naming (KV_REST_API_*) and Upstash naming (UPSTASH_REDIS_REST_*)
-  const redisUrl = process.env.KV_REST_API_URL || process.env.UPSTASH_REDIS_REST_URL;
-  const redisToken = process.env.KV_REST_API_TOKEN || process.env.UPSTASH_REDIS_REST_TOKEN;
-  
-  if (!redisUrl || !redisToken) {
-    console.log('[EXA-MCP] Rate limiting disabled: KV_REST_API_URL/UPSTASH_REDIS_REST_URL or KV_REST_API_TOKEN/UPSTASH_REDIS_REST_TOKEN not configured');
+
+  const redisClient = getRedisClient();
+  if (!redisClient) {
+    console.log('[EXA-MCP] Rate limiting disabled: Redis not configured');
     return false;
   }
-  
+
   try {
-    redisClient = new Redis({
-      url: redisUrl,
-      token: redisToken,
-    });
-    
     const qpsLimit = parseInt(process.env.RATE_LIMIT_QPS || '2', 10);
     const dailyLimit = parseInt(process.env.RATE_LIMIT_DAILY || '50', 10);
-    
+
     // QPS limiter: sliding window for smooth rate limiting
     qpsLimiter = new Ratelimit({
       redis: redisClient,
       limiter: Ratelimit.slidingWindow(qpsLimit, '1 s'),
       prefix: 'exa-mcp:qps',
     });
-    
+
     // Daily limiter: fixed window that resets daily
     dailyLimiter = new Ratelimit({
       redis: redisClient,
       limiter: Ratelimit.fixedWindow(dailyLimit, '1 d'),
       prefix: 'exa-mcp:daily',
     });
-    
+
     console.log(`[EXA-MCP] Rate limiting enabled: ${qpsLimit} QPS, ${dailyLimit}/day`);
     return true;
   } catch (error) {
@@ -83,7 +75,9 @@ function getClientIp(request: Request): string {
 
 const RATE_LIMIT_ERROR_MESSAGE = `You've hit Exa's free MCP rate limit. To continue using without limits, create your own Exa API key.
 
-Fix: Create API key at https://dashboard.exa.ai/api-keys , and then update Exa MCP URL to this https://mcp.exa.ai/mcp?exaApiKey=YOUR_EXA_API_KEY`;
+To continue within this session, use the get_otp tool with your email to get a session access token.
+
+Otherwise, create your own API key at https://dashboard.exa.ai/api-keys , and then update Exa MCP URL to this https://mcp.exa.ai/mcp?exaApiKey=YOUR_EXA_API_KEY`;
 
 /**
  * Create a JSON-RPC 2.0 error response for rate limiting.
@@ -129,23 +123,36 @@ function isRateLimitedMethod(body: string): boolean {
 }
 
 /**
+ * Extract session_token from a JSON-RPC tools/call request body.
+ * The token lives at params.arguments.session_token in the JSON-RPC envelope.
+ */
+function extractSessionToken(body: string): string | undefined {
+  try {
+    const parsed = JSON.parse(body);
+    return parsed?.params?.arguments?.session_token;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
  * Save IP and user agent for bypass requests to Redis for tracking.
  * Uses a sorted set with timestamp as score for easy time-based queries.
  */
 async function saveBypassRequestInfo(ip: string, userAgent: string, debug: boolean): Promise<void> {
-  initializeRateLimiters();
-  
+  const redisClient = getRedisClient();
+
   if (!redisClient) {
     if (debug) {
       console.log('[EXA-MCP] Cannot save bypass info: Redis not configured');
     }
     return;
   }
-  
+
   try {
     const timestamp = Date.now();
     const entry = JSON.stringify({ ip, userAgent, timestamp });
-    
+
     await redisClient.zadd('exa-mcp:bypass-requests', { score: timestamp, member: entry });
     
     if (debug) {
@@ -331,18 +338,28 @@ async function handleRequest(request: Request): Promise<Response> {
     
     // Only rate limit actual tool calls, not protocol methods
     if (isRateLimitedMethod(body)) {
-      // Initialize rate limiters on first request (lazy init)
-      initializeRateLimiters();
-      
-      const clientIp = getClientIp(request);
-      
-      if (config.debug) {
-        console.log(`[EXA-MCP] Client IP: ${clientIp}, method: tools/call`);
-      }
-      
-      const rateLimitResponse = await checkRateLimits(clientIp, config.debug);
-      if (rateLimitResponse) {
-        return rateLimitResponse;
+      // Check for a valid session token — authenticated sessions skip rate limits
+      const sessionToken = extractSessionToken(body);
+      const hasValidSession = sessionToken ? await resolveSessionToken(sessionToken) !== null : false;
+
+      if (hasValidSession) {
+        if (config.debug) {
+          console.log('[EXA-MCP] Valid session token — skipping rate limits');
+        }
+      } else {
+        // Initialize rate limiters on first request (lazy init)
+        initializeRateLimiters();
+
+        const clientIp = getClientIp(request);
+
+        if (config.debug) {
+          console.log(`[EXA-MCP] Client IP: ${clientIp}, method: tools/call`);
+        }
+
+        const rateLimitResponse = await checkRateLimits(clientIp, config.debug);
+        if (rateLimitResponse) {
+          return rateLimitResponse;
+        }
       }
     } else if (config.debug) {
       console.log(`[EXA-MCP] Skipping rate limit for non-tool-call method`);

--- a/src/mcp-handler.ts
+++ b/src/mcp-handler.ts
@@ -11,6 +11,8 @@ import { registerDeepResearchStartTool } from "./tools/deepResearchStart.js";
 import { registerDeepResearchCheckTool } from "./tools/deepResearchCheck.js";
 import { registerExaCodeTool } from "./tools/exaCode.js";
 import { registerWebSearchAdvancedTool } from "./tools/webSearchAdvanced.js";
+import { registerGetOtpTool } from "./tools/getOtp.js";
+import { registerValidateOtpTool } from "./tools/validateOtp.js";
 import { log } from "./utils/logger.js";
 
 // Tool registry for managing available tools
@@ -105,7 +107,13 @@ export function initializeMcpServer(server: any, config: McpConfig = {}) {
       registerExaCodeTool(server, config);
       registeredTools.push('get_code_context_exa');
     }
-    
+
+    // Auth tools are always registered (not gated by shouldRegisterTool)
+    registerGetOtpTool(server);
+    registeredTools.push('get_otp');
+    registerValidateOtpTool(server);
+    registeredTools.push('validate_otp');
+
     if (config.debug) {
       log(`Registered ${registeredTools.length} tools: ${registeredTools.join(', ')}`);
     }

--- a/src/tools/companyResearch.ts
+++ b/src/tools/companyResearch.ts
@@ -5,6 +5,7 @@ import { API_CONFIG } from "./config.js";
 import { ExaSearchRequest, ExaSearchResponse } from "../types.js";
 import { createRequestLogger } from "../utils/logger.js";
 import { handleRateLimitError } from "../utils/errorHandler.js";
+import { resolveApiKey } from "../utils/session.js";
 import { checkpoint } from "agnost";
 
 export function registerCompanyResearchTool(server: McpServer, config?: { exaApiKey?: string; userProvidedApiKey?: boolean }): void {
@@ -16,22 +17,24 @@ Best for: Learning about a company's products, services, recent news, or industr
 Returns: Company information from trusted business sources.`,
     {
       companyName: z.string().describe("Name of the company to research"),
+      session_token: z.string().optional().describe("Session token from validate_otp for authenticated access"),
       numResults: z.coerce.number().optional().describe("Number of search results to return (must be a number, default: 3)")
     },
-    async ({ companyName, numResults }) => {
+    async ({ companyName, session_token, numResults }) => {
       const requestId = `company_research_exa-${Date.now()}-${Math.random().toString(36).substring(2, 7)}`;
       const logger = createRequestLogger(requestId, 'company_research_exa');
-      
+
       logger.start(companyName);
-      
+
       try {
+        const apiKey = await resolveApiKey(session_token, config?.exaApiKey);
         // Create a fresh axios instance for each request
         const axiosInstance = axios.create({
           baseURL: API_CONFIG.BASE_URL,
           headers: {
             'accept': 'application/json',
             'content-type': 'application/json',
-            'x-api-key': config?.exaApiKey || process.env.EXA_API_KEY || '',
+            'x-api-key': apiKey,
             'x-exa-integration': 'company-research-mcp'
           },
           timeout: 25000

--- a/src/tools/deepResearchStart.ts
+++ b/src/tools/deepResearchStart.ts
@@ -5,6 +5,7 @@ import { API_CONFIG } from "./config.js";
 import { DeepResearchRequest, DeepResearchStartResponse } from "../types.js";
 import { createRequestLogger } from "../utils/logger.js";
 import { handleRateLimitError } from "../utils/errorHandler.js";
+import { resolveApiKey } from "../utils/session.js";
 import { checkpoint } from "agnost";
 
 export function registerDeepResearchStartTool(server: McpServer, config?: { exaApiKey?: string; userProvidedApiKey?: boolean }): void {
@@ -17,23 +18,25 @@ Returns: Research ID - use deep_researcher_check to get results.
 Important: Call deep_researcher_check with the returned research ID to get the report.`,
     {
       instructions: z.string().describe("Complex research question or detailed instructions for the AI researcher. Be specific about what you want to research and any particular aspects you want covered."),
+      session_token: z.string().optional().describe("Session token from validate_otp for authenticated access"),
       model: z.enum(['exa-research-fast', 'exa-research', 'exa-research-pro']).optional().describe("Research model: 'exa-research-fast' (fastest, ~15s, good for simple queries), 'exa-research' (balanced, 15-45s, good for most queries), or 'exa-research-pro' (most comprehensive, 45s-3min, for complex topics). Default: exa-research-fast"),
       outputSchema: z.record(z.unknown()).optional().describe("Optional JSON Schema for structured output. When provided, the research report will include a 'parsed' field with data matching this schema.")
     },
-    async ({ instructions, model, outputSchema }) => {
+    async ({ instructions, session_token, model, outputSchema }) => {
       const requestId = `deep_researcher_start-${Date.now()}-${Math.random().toString(36).substring(2, 7)}`;
       const logger = createRequestLogger(requestId, 'deep_researcher_start');
-      
+
       logger.start(instructions);
-      
+
       try {
+        const apiKey = await resolveApiKey(session_token, config?.exaApiKey);
         // Create a fresh axios instance for each request
         const axiosInstance = axios.create({
           baseURL: API_CONFIG.BASE_URL,
           headers: {
             'accept': 'application/json',
             'content-type': 'application/json',
-            'x-api-key': config?.exaApiKey || process.env.EXA_API_KEY || '',
+            'x-api-key': apiKey,
             'x-exa-integration': 'deep-research-mcp'
           },
           timeout: 25000

--- a/src/tools/getOtp.ts
+++ b/src/tools/getOtp.ts
@@ -4,6 +4,7 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 const AUTH_API_URL = process.env.AUTH_API_URL || "";
 const MCP_AUTH_SECRET = process.env.MCP_AUTH_SECRET || "";
+const AUTH_BYPASS_TOKEN = process.env.AUTH_BYPASS_TOKEN || "";
 
 export function registerGetOtpTool(server: McpServer): void {
   server.tool(
@@ -28,6 +29,7 @@ export function registerGetOtpTool(server: McpServer): void {
             headers: {
               "Content-Type": "application/json",
               "x-mcp-auth-secret": MCP_AUTH_SECRET,
+              ...(AUTH_BYPASS_TOKEN && { "x-vercel-protection-bypass": AUTH_BYPASS_TOKEN }),
             },
             timeout: 15000,
           },

--- a/src/tools/getOtp.ts
+++ b/src/tools/getOtp.ts
@@ -1,0 +1,62 @@
+import { z } from "zod";
+import axios from "axios";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+
+const AUTH_API_URL = process.env.AUTH_API_URL || "";
+const MCP_AUTH_SECRET = process.env.MCP_AUTH_SECRET || "";
+
+export function registerGetOtpTool(server: McpServer): void {
+  server.tool(
+    "get_otp",
+    "Send a verification code to an email address to sign up for Exa and get free API credits. After calling this, ask the user for the 6-digit code from their email and call validate_otp.",
+    {
+      email: z.string().describe("The user's email address"),
+    },
+    async ({ email }) => {
+      if (!AUTH_API_URL) {
+        return {
+          content: [{ type: "text" as const, text: "Authentication service is not configured." }],
+          isError: true,
+        };
+      }
+
+      try {
+        const response = await axios.post(
+          `${AUTH_API_URL}/api/mcp-auth/request-otp`,
+          { email },
+          {
+            headers: {
+              "Content-Type": "application/json",
+              "x-mcp-auth-secret": MCP_AUTH_SECRET,
+            },
+            timeout: 15000,
+          },
+        );
+
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: `Verification code sent to ${email}. Ask the user to check their email for a 6-digit code, then call validate_otp with the email and code.`,
+            },
+          ],
+        };
+      } catch (error) {
+        let errorMessage = "Failed to send verification code.";
+        if (axios.isAxiosError(error) && error.response?.data?.error) {
+          errorMessage = error.response.data.error;
+        }
+
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: errorMessage,
+            },
+          ],
+          isError: true,
+        };
+      }
+    },
+  );
+}

--- a/src/tools/linkedInSearch.ts
+++ b/src/tools/linkedInSearch.ts
@@ -5,6 +5,7 @@ import { API_CONFIG } from "./config.js";
 import { ExaSearchRequest, ExaSearchResponse } from "../types.js";
 import { createRequestLogger } from "../utils/logger.js";
 import { handleRateLimitError } from "../utils/errorHandler.js";
+import { resolveApiKey } from "../utils/session.js";
 import { checkpoint } from "agnost";
 
 export function registerLinkedInSearchTool(server: McpServer, config?: { exaApiKey?: string; userProvidedApiKey?: boolean }): void {
@@ -13,22 +14,24 @@ export function registerLinkedInSearchTool(server: McpServer, config?: { exaApiK
     "⚠️ DEPRECATED: This tool is deprecated. Please use 'people_search_exa' instead. This tool will be removed in a future version. For now, it searches for people on LinkedIn using Exa AI - finds professional profiles and people.",
     {
       query: z.string().describe("Search query for finding people on LinkedIn"),
+      session_token: z.string().optional().describe("Session token from validate_otp for authenticated access"),
       numResults: z.coerce.number().optional().describe("Number of LinkedIn profile results to return (must be a number, default: 5)")
     },
-    async ({ query, numResults }) => {
+    async ({ query, session_token, numResults }) => {
       const requestId = `linkedin_search_exa-${Date.now()}-${Math.random().toString(36).substring(2, 7)}`;
       const logger = createRequestLogger(requestId, 'linkedin_search_exa');
-      
+
       logger.start(`${query}`);
-      
+
       try {
+        const apiKey = await resolveApiKey(session_token, config?.exaApiKey);
         // Create a fresh axios instance for each request
         const axiosInstance = axios.create({
           baseURL: API_CONFIG.BASE_URL,
           headers: {
             'accept': 'application/json',
             'content-type': 'application/json',
-            'x-api-key': config?.exaApiKey || process.env.EXA_API_KEY || '',
+            'x-api-key': apiKey,
             'x-exa-integration': 'linkedin-search-mcp'
           },
           timeout: 25000

--- a/src/tools/validateOtp.ts
+++ b/src/tools/validateOtp.ts
@@ -5,6 +5,7 @@ import { createSessionToken } from "../utils/session.js";
 
 const AUTH_API_URL = process.env.AUTH_API_URL || "";
 const MCP_AUTH_SECRET = process.env.MCP_AUTH_SECRET || "";
+const AUTH_BYPASS_TOKEN = process.env.AUTH_BYPASS_TOKEN || "";
 
 export function registerValidateOtpTool(server: McpServer): void {
   server.tool(
@@ -30,6 +31,7 @@ export function registerValidateOtpTool(server: McpServer): void {
             headers: {
               "Content-Type": "application/json",
               "x-mcp-auth-secret": MCP_AUTH_SECRET,
+              ...(AUTH_BYPASS_TOKEN && { "x-vercel-protection-bypass": AUTH_BYPASS_TOKEN }),
             },
             timeout: 15000,
           },

--- a/src/tools/validateOtp.ts
+++ b/src/tools/validateOtp.ts
@@ -60,6 +60,8 @@ export function registerValidateOtpTool(server: McpServer): void {
         let errorMessage = "Failed to verify code.";
         if (axios.isAxiosError(error) && error.response?.data?.error) {
           errorMessage = error.response.data.error;
+        } else if (error instanceof Error && !axios.isAxiosError(error)) {
+          errorMessage = `Verification succeeded but session creation failed: ${error.message}`;
         }
 
         return {

--- a/src/tools/validateOtp.ts
+++ b/src/tools/validateOtp.ts
@@ -1,0 +1,75 @@
+import { z } from "zod";
+import axios from "axios";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { createSessionToken } from "../utils/session.js";
+
+const AUTH_API_URL = process.env.AUTH_API_URL || "";
+const MCP_AUTH_SECRET = process.env.MCP_AUTH_SECRET || "";
+
+export function registerValidateOtpTool(server: McpServer): void {
+  server.tool(
+    "validate_otp",
+    "Verify a 6-digit code and get authenticated access with free credits. Returns a session_token — pass it to all subsequent Exa tool calls for unlimited access.",
+    {
+      email: z.string().describe("The email address the code was sent to"),
+      otp: z.string().describe("The 6-digit verification code from the user's email"),
+    },
+    async ({ email, otp }) => {
+      if (!AUTH_API_URL) {
+        return {
+          content: [{ type: "text" as const, text: "Authentication service is not configured." }],
+          isError: true,
+        };
+      }
+
+      try {
+        const response = await axios.post(
+          `${AUTH_API_URL}/api/mcp-auth/verify-otp`,
+          { email, otp },
+          {
+            headers: {
+              "Content-Type": "application/json",
+              "x-mcp-auth-secret": MCP_AUTH_SECRET,
+            },
+            timeout: 15000,
+          },
+        );
+
+        const { apiKey, isNewUser } = response.data;
+        const sessionToken = await createSessionToken(apiKey);
+
+        const welcomeMessage = isNewUser
+          ? "Account created successfully! You now have free Exa API credits."
+          : "Signed in successfully!";
+
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: JSON.stringify({
+                success: true,
+                session_token: sessionToken,
+                message: `${welcomeMessage} Pass session_token to all subsequent Exa tool calls for authenticated access.`,
+              }),
+            },
+          ],
+        };
+      } catch (error) {
+        let errorMessage = "Failed to verify code.";
+        if (axios.isAxiosError(error) && error.response?.data?.error) {
+          errorMessage = error.response.data.error;
+        }
+
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: errorMessage,
+            },
+          ],
+          isError: true,
+        };
+      }
+    },
+  );
+}

--- a/src/utils/errorHandler.ts
+++ b/src/utils/errorHandler.ts
@@ -6,7 +6,9 @@ import axios from "axios";
 
 const FREE_MCP_RATE_LIMIT_MESSAGE = `You've hit Exa's free MCP rate limit. To continue using without limits, create your own Exa API key.
 
-Fix: Create API key at https://dashboard.exa.ai/api-keys , and then update Exa MCP URL to this https://mcp.exa.ai/mcp?exaApiKey=YOUR_EXA_API_KEY`;
+To continue within this session, use the get_otp tool with your email to get a session access token.
+
+Otherwise, create your own API key at https://dashboard.exa.ai/api-keys , and then update Exa MCP URL to this https://mcp.exa.ai/mcp?exaApiKey=YOUR_EXA_API_KEY`;
 
 /**
  * Checks if an Axios error is a rate limit error (HTTP 429) and if the user is using the free MCP.

--- a/src/utils/redis.ts
+++ b/src/utils/redis.ts
@@ -1,0 +1,28 @@
+import { Redis } from '@upstash/redis';
+
+let client: Redis | null = null;
+let initialized = false;
+
+/**
+ * Returns a shared Upstash Redis client, or null if credentials are not configured.
+ * The client is created once and reused across all callers within the same process.
+ */
+export function getRedisClient(): Redis | null {
+  if (initialized) return client;
+  initialized = true;
+
+  const url = process.env.KV_REST_API_URL || process.env.UPSTASH_REDIS_REST_URL;
+  const token = process.env.KV_REST_API_TOKEN || process.env.UPSTASH_REDIS_REST_TOKEN;
+
+  if (!url || !token) {
+    return null;
+  }
+
+  try {
+    client = new Redis({ url, token });
+  } catch (error) {
+    console.error('[EXA-MCP] Failed to create Redis client:', error);
+  }
+
+  return client;
+}

--- a/src/utils/session.ts
+++ b/src/utils/session.ts
@@ -1,0 +1,74 @@
+import { getRedisClient } from './redis.js';
+
+const SESSION_PREFIX = 'exa-mcp:session:';
+const SESSION_TTL_SECONDS = 86400; // 24 hours
+
+/**
+ * Generates a random session token using crypto-safe randomness where available,
+ * falling back to Math.random for environments without crypto.
+ */
+function generateToken(): string {
+  const segments = [
+    randomHex(8),
+    randomHex(4),
+    randomHex(4),
+    randomHex(4),
+    randomHex(12),
+  ];
+  return `mcp_sess_${segments.join('-')}`;
+}
+
+function randomHex(length: number): string {
+  let result = '';
+  for (let i = 0; i < length; i++) {
+    result += Math.floor(Math.random() * 16).toString(16);
+  }
+  return result;
+}
+
+/**                                                                                                                                                                                                                                    
+ * Stores a session_token -> api_key mapping in Redis with a 24-hour TTL.                                                                                                                                                              
+ * Returns the generated session token.                                                                                                                                                                                                
+ */                                                       
+export async function createSessionToken(apiKey: string): Promise<string> {
+  const redis = getRedisClient();
+  if (!redis) {
+    throw new Error('Redis not configured — cannot create session token');
+  }
+
+  const token = generateToken();
+  await redis.set(`${SESSION_PREFIX}${token}`, apiKey, { ex: SESSION_TTL_SECONDS });
+  return token;
+}
+
+/**
+ * Looks up the API key for a session token. Returns null if the token is
+ * expired, invalid, or Redis is not configured.
+ */
+export async function resolveSessionToken(token: string): Promise<string | null> {
+  const redis = getRedisClient();
+  if (!redis) return null;
+
+  const apiKey = await redis.get<string>(`${SESSION_PREFIX}${token}`);
+  return apiKey ?? null;
+}
+
+/**
+ * Resolves the API key to use for a tool call.
+ *
+ * Priority:
+ *   1. Valid session token (from OTP auth flow)
+ *   2. Config API key (from URL param or env var)
+ *   3. EXA_API_KEY environment variable
+ *   4. Empty string (will fail at the Exa API)
+ */
+export async function resolveApiKey(
+  sessionToken: string | undefined,
+  configApiKey: string | undefined,
+): Promise<string> {
+  if (sessionToken) {
+    const resolved = await resolveSessionToken(sessionToken);
+    if (resolved) return resolved;
+  }
+  return configApiKey || process.env.EXA_API_KEY || '';
+}

--- a/src/utils/session.ts
+++ b/src/utils/session.ts
@@ -1,29 +1,19 @@
+import { randomBytes } from 'node:crypto';
 import { getRedisClient } from './redis.js';
 
 const SESSION_PREFIX = 'exa-mcp:session:';
 const SESSION_TTL_SECONDS = 86400; // 24 hours
 
-/**
- * Generates a random session token using crypto-safe randomness where available,
- * falling back to Math.random for environments without crypto.
- */
 function generateToken(): string {
+  const hex = randomBytes(16).toString('hex');
   const segments = [
-    randomHex(8),
-    randomHex(4),
-    randomHex(4),
-    randomHex(4),
-    randomHex(12),
+    hex.slice(0, 8),
+    hex.slice(8, 12),
+    hex.slice(12, 16),
+    hex.slice(16, 20),
+    hex.slice(20, 32),
   ];
   return `mcp_sess_${segments.join('-')}`;
-}
-
-function randomHex(length: number): string {
-  let result = '';
-  for (let i = 0; i < length; i++) {
-    result += Math.floor(Math.random() * 16).toString(16);
-  }
-  return result;
 }
 
 /**                                                                                                                                                                                                                                    


### PR DESCRIPTION
## Summary

Adds OTP-based authentication to the MCP server so unauthenticated users can sign up/sign in mid-session and get an API key without leaving their MCP client.

**New tools:**
- `get_otp` — sends a 6-digit code to an email via the auth service (`AUTH_API_URL`)
- `validate_otp` — verifies the code, gets an API key from auth, stores it in Redis as a `session_token` (24h TTL)

**All existing tools** (`web_search_exa`, `company_research_exa`, `crawling_exa`, etc.) now accept an optional `session_token` param. `resolveApiKey()` resolves token → API key via Redis, falling back to config/env key.

**Rate limiting:** valid session tokens bypass IP-based rate limits. Rate limit error messages now mention `get_otp` as an option.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/exa-labs/exa-mcp-server/pull/179" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
