### PR TITLE
[exa-mcp-server]: compact installation configs with single-line JSON

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,179 +19,110 @@ https://mcp.exa.ai/mcp
 
 [Get your API key](https://dashboard.exa.ai/api-keys)
 
-<details>
-<summary><b>Cursor</b> · <b>VS Code</b> · <b>Claude Code</b> · <b>Claude Desktop</b> · <b>Codex</b> · <b>OpenCode</b> · <b>Antigravity</b> · <b>Windsurf</b> · <b>Zed</b> · <b>Gemini CLI</b> · <b>v0</b> · <b>Warp</b> · <b>Kiro</b> · <b>Roo Code</b> · <b>Other Clients</b> · <b>npm Package</b></summary>
+[![Cursor](https://img.shields.io/badge/Cursor-333?style=flat-square)](#cursor) [![VS Code](https://img.shields.io/badge/VS_Code-007ACC?style=flat-square&logo=visualstudiocode&logoColor=white)](#vs-code) [![Claude Code](https://img.shields.io/badge/Claude_Code-D4A574?style=flat-square)](#claude-code) [![Claude Desktop](https://img.shields.io/badge/Claude_Desktop-D4A574?style=flat-square)](#claude-desktop) [![Codex](https://img.shields.io/badge/Codex-10A37F?style=flat-square)](#codex) [![OpenCode](https://img.shields.io/badge/OpenCode-555?style=flat-square)](#opencode) [![Antigravity](https://img.shields.io/badge/Antigravity-555?style=flat-square)](#antigravity) [![Windsurf](https://img.shields.io/badge/Windsurf-0FC?style=flat-square)](#windsurf) [![Zed](https://img.shields.io/badge/Zed-555?style=flat-square)](#zed) [![Gemini CLI](https://img.shields.io/badge/Gemini_CLI-4285F4?style=flat-square)](#gemini-cli) [![v0](https://img.shields.io/badge/v0_by_Vercel-000?style=flat-square)](#v0-by-vercel) [![Warp](https://img.shields.io/badge/Warp-01A4FF?style=flat-square)](#warp) [![Kiro](https://img.shields.io/badge/Kiro-FF9900?style=flat-square)](#kiro) [![Roo Code](https://img.shields.io/badge/Roo_Code-555?style=flat-square)](#roo-code) [![Other](https://img.shields.io/badge/Other_Clients-888?style=flat-square)](#other-clients) [![npm](https://img.shields.io/badge/npm_Package-CB3837?style=flat-square&logo=npm&logoColor=white)](#via-npm-package)
 
-### CLI
+<h4 id="cursor">Cursor</h4>
 
-```bash
-claude mcp add --transport http exa https://mcp.exa.ai/mcp   # Claude Code
-codex mcp add exa --url https://mcp.exa.ai/mcp               # Codex
-```
-
-### UI
-
-- **Antigravity** — MCP Store panel (from "..." dropdown) → add custom server → `https://mcp.exa.ai/mcp`
-- **v0 by Vercel** — Prompt Tools → Add MCP → `https://mcp.exa.ai/mcp`
-- **Warp** — Settings → MCP Servers → Add MCP Server → `{ "exa": { "url": "https://mcp.exa.ai/mcp" } }`
-
-### JSON Config
-
-Add to your client's config file:
-
-| Client | Config File |
-| ------ | ----------- |
-| Cursor | `~/.cursor/mcp.json` |
-| Kiro | `~/.kiro/settings/mcp.json` |
-
+Add to `~/.cursor/mcp.json`:
 ```json
-{
-  "mcpServers": {
-    "exa": {
-      "url": "https://mcp.exa.ai/mcp"
-    }
-  }
-}
+{ "mcpServers": { "exa": { "url": "https://mcp.exa.ai/mcp" } } }
 ```
 
-<details>
-<summary>VS Code</summary>
+<h4 id="vs-code">VS Code</h4>
 
 Add to `.vscode/mcp.json`:
 ```json
-{
-  "servers": {
-    "exa": {
-      "type": "http",
-      "url": "https://mcp.exa.ai/mcp"
-    }
-  }
-}
+{ "servers": { "exa": { "type": "http", "url": "https://mcp.exa.ai/mcp" } } }
 ```
-</details>
 
-<details>
-<summary>Claude Desktop</summary>
+<h4 id="claude-code">Claude Code</h4>
 
-Config file — **macOS:** `~/Library/Application Support/Claude/claude_desktop_config.json` · **Windows:** `%APPDATA%\Claude\claude_desktop_config.json`
+```bash
+claude mcp add --transport http exa https://mcp.exa.ai/mcp
+```
+
+<h4 id="claude-desktop">Claude Desktop</h4>
+
+**macOS:** `~/Library/Application Support/Claude/claude_desktop_config.json` · **Windows:** `%APPDATA%\Claude\claude_desktop_config.json`
 ```json
-{
-  "mcpServers": {
-    "exa": {
-      "command": "npx",
-      "args": ["-y", "mcp-remote", "https://mcp.exa.ai/mcp"]
-    }
-  }
-}
+{ "mcpServers": { "exa": { "command": "npx", "args": ["-y", "mcp-remote", "https://mcp.exa.ai/mcp"] } } }
 ```
-</details>
 
-<details>
-<summary>OpenCode</summary>
+<h4 id="codex">Codex</h4>
+
+```bash
+codex mcp add exa --url https://mcp.exa.ai/mcp
+```
+
+<h4 id="opencode">OpenCode</h4>
 
 Add to `opencode.json`:
 ```json
-{
-  "mcp": {
-    "exa": {
-      "type": "remote",
-      "url": "https://mcp.exa.ai/mcp",
-      "enabled": true
-    }
-  }
-}
+{ "mcp": { "exa": { "type": "remote", "url": "https://mcp.exa.ai/mcp", "enabled": true } } }
 ```
-</details>
 
-<details>
-<summary>Windsurf</summary>
+<h4 id="antigravity">Antigravity</h4>
+
+Open the MCP Store panel (from the "..." dropdown) → add custom server → `https://mcp.exa.ai/mcp`
+
+<h4 id="windsurf">Windsurf</h4>
 
 Add to `~/.codeium/windsurf/mcp_config.json`:
 ```json
-{
-  "mcpServers": {
-    "exa": {
-      "serverUrl": "https://mcp.exa.ai/mcp"
-    }
-  }
-}
+{ "mcpServers": { "exa": { "serverUrl": "https://mcp.exa.ai/mcp" } } }
 ```
-</details>
 
-<details>
-<summary>Zed</summary>
+<h4 id="zed">Zed</h4>
 
 Add to your Zed settings:
 ```json
-{
-  "context_servers": {
-    "exa": {
-      "url": "https://mcp.exa.ai/mcp"
-    }
-  }
-}
+{ "context_servers": { "exa": { "url": "https://mcp.exa.ai/mcp" } } }
 ```
-</details>
 
-<details>
-<summary>Gemini CLI</summary>
+<h4 id="gemini-cli">Gemini CLI</h4>
 
 Add to `~/.gemini/settings.json`:
 ```json
-{
-  "mcpServers": {
-    "exa": {
-      "httpUrl": "https://mcp.exa.ai/mcp"
-    }
-  }
-}
+{ "mcpServers": { "exa": { "httpUrl": "https://mcp.exa.ai/mcp" } } }
 ```
-</details>
 
-<details>
-<summary>Roo Code</summary>
+<h4 id="v0-by-vercel">v0 by Vercel</h4>
+
+Select **Prompt Tools** → **Add MCP** → `https://mcp.exa.ai/mcp`
+
+<h4 id="warp">Warp</h4>
+
+**Settings** → **MCP Servers** → **Add MCP Server**:
+```json
+{ "exa": { "url": "https://mcp.exa.ai/mcp" } }
+```
+
+<h4 id="kiro">Kiro</h4>
+
+Add to `~/.kiro/settings/mcp.json`:
+```json
+{ "mcpServers": { "exa": { "url": "https://mcp.exa.ai/mcp" } } }
+```
+
+<h4 id="roo-code">Roo Code</h4>
 
 Add to your Roo Code MCP config:
 ```json
-{
-  "mcpServers": {
-    "exa": {
-      "type": "streamable-http",
-      "url": "https://mcp.exa.ai/mcp"
-    }
-  }
-}
+{ "mcpServers": { "exa": { "type": "streamable-http", "url": "https://mcp.exa.ai/mcp" } } }
 ```
-</details>
 
-<details>
-<summary>Other Clients</summary>
+<h4 id="other-clients">Other Clients</h4>
 
 For clients that support remote MCP:
 ```json
-{
-  "mcpServers": {
-    "exa": {
-      "url": "https://mcp.exa.ai/mcp"
-    }
-  }
-}
+{ "mcpServers": { "exa": { "url": "https://mcp.exa.ai/mcp" } } }
 ```
 For clients that need mcp-remote:
 ```json
-{
-  "mcpServers": {
-    "exa": {
-      "command": "npx",
-      "args": ["-y", "mcp-remote", "https://mcp.exa.ai/mcp"]
-    }
-  }
-}
+{ "mcpServers": { "exa": { "command": "npx", "args": ["-y", "mcp-remote", "https://mcp.exa.ai/mcp"] } } }
 ```
-</details>
 
-<details>
-<summary>Via npm Package</summary>
+<h4 id="via-npm-package">Via npm Package</h4>
 
 Use the npm package with your API key. [Get your API key](https://dashboard.exa.ai/api-keys).
 ```json
@@ -200,16 +131,11 @@ Use the npm package with your API key. [Get your API key](https://dashboard.exa.
     "exa": {
       "command": "npx",
       "args": ["-y", "exa-mcp-server"],
-      "env": {
-        "EXA_API_KEY": "your_api_key"
-      }
+      "env": { "EXA_API_KEY": "your_api_key" }
     }
   }
 }
 ```
-</details>
-
-</details>
 
 ## Available Tools
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ https://mcp.exa.ai/mcp
 [Get your API key](https://dashboard.exa.ai/api-keys)
 
 <details>
-<summary><img src="https://img.shields.io/badge/Cursor-333?style=flat-square" alt="Cursor"></summary>
+<summary><b>Cursor</b></summary>
 
 Add to `~/.cursor/mcp.json`:
 ```json
@@ -29,7 +29,7 @@ Add to `~/.cursor/mcp.json`:
 </details>
 
 <details>
-<summary><img src="https://img.shields.io/badge/VS_Code-007ACC?style=flat-square&logo=visualstudiocode&logoColor=white" alt="VS Code"></summary>
+<summary><b>VS Code</b></summary>
 
 Add to `.vscode/mcp.json`:
 ```json
@@ -38,7 +38,7 @@ Add to `.vscode/mcp.json`:
 </details>
 
 <details>
-<summary><img src="https://img.shields.io/badge/Claude_Code-D4A574?style=flat-square" alt="Claude Code"></summary>
+<summary><b>Claude Code</b></summary>
 
 ```bash
 claude mcp add --transport http exa https://mcp.exa.ai/mcp
@@ -46,7 +46,7 @@ claude mcp add --transport http exa https://mcp.exa.ai/mcp
 </details>
 
 <details>
-<summary><img src="https://img.shields.io/badge/Claude_Desktop-D4A574?style=flat-square" alt="Claude Desktop"></summary>
+<summary><b>Claude Desktop</b></summary>
 
 **macOS:** `~/Library/Application Support/Claude/claude_desktop_config.json` · **Windows:** `%APPDATA%\Claude\claude_desktop_config.json`
 ```json
@@ -55,7 +55,7 @@ claude mcp add --transport http exa https://mcp.exa.ai/mcp
 </details>
 
 <details>
-<summary><img src="https://img.shields.io/badge/Codex-10A37F?style=flat-square" alt="Codex"></summary>
+<summary><b>Codex</b></summary>
 
 ```bash
 codex mcp add exa --url https://mcp.exa.ai/mcp
@@ -63,7 +63,7 @@ codex mcp add exa --url https://mcp.exa.ai/mcp
 </details>
 
 <details>
-<summary><img src="https://img.shields.io/badge/OpenCode-555?style=flat-square" alt="OpenCode"></summary>
+<summary><b>OpenCode</b></summary>
 
 Add to `opencode.json`:
 ```json
@@ -72,13 +72,13 @@ Add to `opencode.json`:
 </details>
 
 <details>
-<summary><img src="https://img.shields.io/badge/Antigravity-555?style=flat-square" alt="Antigravity"></summary>
+<summary><b>Antigravity</b></summary>
 
 Open the MCP Store panel (from the "..." dropdown) → add custom server → `https://mcp.exa.ai/mcp`
 </details>
 
 <details>
-<summary><img src="https://img.shields.io/badge/Windsurf-0FC?style=flat-square" alt="Windsurf"></summary>
+<summary><b>Windsurf</b></summary>
 
 Add to `~/.codeium/windsurf/mcp_config.json`:
 ```json
@@ -87,7 +87,7 @@ Add to `~/.codeium/windsurf/mcp_config.json`:
 </details>
 
 <details>
-<summary><img src="https://img.shields.io/badge/Zed-555?style=flat-square" alt="Zed"></summary>
+<summary><b>Zed</b></summary>
 
 Add to your Zed settings:
 ```json
@@ -96,7 +96,7 @@ Add to your Zed settings:
 </details>
 
 <details>
-<summary><img src="https://img.shields.io/badge/Gemini_CLI-4285F4?style=flat-square" alt="Gemini CLI"></summary>
+<summary><b>Gemini CLI</b></summary>
 
 Add to `~/.gemini/settings.json`:
 ```json
@@ -105,13 +105,13 @@ Add to `~/.gemini/settings.json`:
 </details>
 
 <details>
-<summary><img src="https://img.shields.io/badge/v0_by_Vercel-000?style=flat-square" alt="v0 by Vercel"></summary>
+<summary><b>v0 by Vercel</b></summary>
 
 Select **Prompt Tools** → **Add MCP** → `https://mcp.exa.ai/mcp`
 </details>
 
 <details>
-<summary><img src="https://img.shields.io/badge/Warp-01A4FF?style=flat-square" alt="Warp"></summary>
+<summary><b>Warp</b></summary>
 
 **Settings** → **MCP Servers** → **Add MCP Server**:
 ```json
@@ -120,7 +120,7 @@ Select **Prompt Tools** → **Add MCP** → `https://mcp.exa.ai/mcp`
 </details>
 
 <details>
-<summary><img src="https://img.shields.io/badge/Kiro-FF9900?style=flat-square" alt="Kiro"></summary>
+<summary><b>Kiro</b></summary>
 
 Add to `~/.kiro/settings/mcp.json`:
 ```json
@@ -129,7 +129,7 @@ Add to `~/.kiro/settings/mcp.json`:
 </details>
 
 <details>
-<summary><img src="https://img.shields.io/badge/Roo_Code-555?style=flat-square" alt="Roo Code"></summary>
+<summary><b>Roo Code</b></summary>
 
 Add to your Roo Code MCP config:
 ```json
@@ -138,7 +138,7 @@ Add to your Roo Code MCP config:
 </details>
 
 <details>
-<summary><img src="https://img.shields.io/badge/Other_Clients-888?style=flat-square" alt="Other Clients"></summary>
+<summary><b>Other Clients</b></summary>
 
 For clients that support remote MCP:
 ```json
@@ -151,7 +151,7 @@ For clients that need mcp-remote:
 </details>
 
 <details>
-<summary><img src="https://img.shields.io/badge/npm_Package-CB3837?style=flat-square&logo=npm&logoColor=white" alt="npm Package"></summary>
+<summary><b>Via npm Package</b></summary>
 
 Use the npm package with your API key. [Get your API key](https://dashboard.exa.ai/api-keys).
 ```json

--- a/README.md
+++ b/README.md
@@ -19,99 +19,126 @@ https://mcp.exa.ai/mcp
 
 [Get your API key](https://dashboard.exa.ai/api-keys)
 
-[![Cursor](https://img.shields.io/badge/Cursor-333?style=flat-square)](#cursor) [![VS Code](https://img.shields.io/badge/VS_Code-007ACC?style=flat-square&logo=visualstudiocode&logoColor=white)](#vs-code) [![Claude Code](https://img.shields.io/badge/Claude_Code-D4A574?style=flat-square)](#claude-code) [![Claude Desktop](https://img.shields.io/badge/Claude_Desktop-D4A574?style=flat-square)](#claude-desktop) [![Codex](https://img.shields.io/badge/Codex-10A37F?style=flat-square)](#codex) [![OpenCode](https://img.shields.io/badge/OpenCode-555?style=flat-square)](#opencode) [![Antigravity](https://img.shields.io/badge/Antigravity-555?style=flat-square)](#antigravity) [![Windsurf](https://img.shields.io/badge/Windsurf-0FC?style=flat-square)](#windsurf) [![Zed](https://img.shields.io/badge/Zed-555?style=flat-square)](#zed) [![Gemini CLI](https://img.shields.io/badge/Gemini_CLI-4285F4?style=flat-square)](#gemini-cli) [![v0](https://img.shields.io/badge/v0_by_Vercel-000?style=flat-square)](#v0-by-vercel) [![Warp](https://img.shields.io/badge/Warp-01A4FF?style=flat-square)](#warp) [![Kiro](https://img.shields.io/badge/Kiro-FF9900?style=flat-square)](#kiro) [![Roo Code](https://img.shields.io/badge/Roo_Code-555?style=flat-square)](#roo-code) [![Other](https://img.shields.io/badge/Other_Clients-888?style=flat-square)](#other-clients) [![npm](https://img.shields.io/badge/npm_Package-CB3837?style=flat-square&logo=npm&logoColor=white)](#via-npm-package)
-
-<h4 id="cursor">Cursor</h4>
+<details>
+<summary><img src="https://img.shields.io/badge/Cursor-333?style=flat-square" alt="Cursor"></summary>
 
 Add to `~/.cursor/mcp.json`:
 ```json
 { "mcpServers": { "exa": { "url": "https://mcp.exa.ai/mcp" } } }
 ```
+</details>
 
-<h4 id="vs-code">VS Code</h4>
+<details>
+<summary><img src="https://img.shields.io/badge/VS_Code-007ACC?style=flat-square&logo=visualstudiocode&logoColor=white" alt="VS Code"></summary>
 
 Add to `.vscode/mcp.json`:
 ```json
 { "servers": { "exa": { "type": "http", "url": "https://mcp.exa.ai/mcp" } } }
 ```
+</details>
 
-<h4 id="claude-code">Claude Code</h4>
+<details>
+<summary><img src="https://img.shields.io/badge/Claude_Code-D4A574?style=flat-square" alt="Claude Code"></summary>
 
 ```bash
 claude mcp add --transport http exa https://mcp.exa.ai/mcp
 ```
+</details>
 
-<h4 id="claude-desktop">Claude Desktop</h4>
+<details>
+<summary><img src="https://img.shields.io/badge/Claude_Desktop-D4A574?style=flat-square" alt="Claude Desktop"></summary>
 
 **macOS:** `~/Library/Application Support/Claude/claude_desktop_config.json` · **Windows:** `%APPDATA%\Claude\claude_desktop_config.json`
 ```json
 { "mcpServers": { "exa": { "command": "npx", "args": ["-y", "mcp-remote", "https://mcp.exa.ai/mcp"] } } }
 ```
+</details>
 
-<h4 id="codex">Codex</h4>
+<details>
+<summary><img src="https://img.shields.io/badge/Codex-10A37F?style=flat-square" alt="Codex"></summary>
 
 ```bash
 codex mcp add exa --url https://mcp.exa.ai/mcp
 ```
+</details>
 
-<h4 id="opencode">OpenCode</h4>
+<details>
+<summary><img src="https://img.shields.io/badge/OpenCode-555?style=flat-square" alt="OpenCode"></summary>
 
 Add to `opencode.json`:
 ```json
 { "mcp": { "exa": { "type": "remote", "url": "https://mcp.exa.ai/mcp", "enabled": true } } }
 ```
+</details>
 
-<h4 id="antigravity">Antigravity</h4>
+<details>
+<summary><img src="https://img.shields.io/badge/Antigravity-555?style=flat-square" alt="Antigravity"></summary>
 
 Open the MCP Store panel (from the "..." dropdown) → add custom server → `https://mcp.exa.ai/mcp`
+</details>
 
-<h4 id="windsurf">Windsurf</h4>
+<details>
+<summary><img src="https://img.shields.io/badge/Windsurf-0FC?style=flat-square" alt="Windsurf"></summary>
 
 Add to `~/.codeium/windsurf/mcp_config.json`:
 ```json
 { "mcpServers": { "exa": { "serverUrl": "https://mcp.exa.ai/mcp" } } }
 ```
+</details>
 
-<h4 id="zed">Zed</h4>
+<details>
+<summary><img src="https://img.shields.io/badge/Zed-555?style=flat-square" alt="Zed"></summary>
 
 Add to your Zed settings:
 ```json
 { "context_servers": { "exa": { "url": "https://mcp.exa.ai/mcp" } } }
 ```
+</details>
 
-<h4 id="gemini-cli">Gemini CLI</h4>
+<details>
+<summary><img src="https://img.shields.io/badge/Gemini_CLI-4285F4?style=flat-square" alt="Gemini CLI"></summary>
 
 Add to `~/.gemini/settings.json`:
 ```json
 { "mcpServers": { "exa": { "httpUrl": "https://mcp.exa.ai/mcp" } } }
 ```
+</details>
 
-<h4 id="v0-by-vercel">v0 by Vercel</h4>
+<details>
+<summary><img src="https://img.shields.io/badge/v0_by_Vercel-000?style=flat-square" alt="v0 by Vercel"></summary>
 
 Select **Prompt Tools** → **Add MCP** → `https://mcp.exa.ai/mcp`
+</details>
 
-<h4 id="warp">Warp</h4>
+<details>
+<summary><img src="https://img.shields.io/badge/Warp-01A4FF?style=flat-square" alt="Warp"></summary>
 
 **Settings** → **MCP Servers** → **Add MCP Server**:
 ```json
 { "exa": { "url": "https://mcp.exa.ai/mcp" } }
 ```
+</details>
 
-<h4 id="kiro">Kiro</h4>
+<details>
+<summary><img src="https://img.shields.io/badge/Kiro-FF9900?style=flat-square" alt="Kiro"></summary>
 
 Add to `~/.kiro/settings/mcp.json`:
 ```json
 { "mcpServers": { "exa": { "url": "https://mcp.exa.ai/mcp" } } }
 ```
+</details>
 
-<h4 id="roo-code">Roo Code</h4>
+<details>
+<summary><img src="https://img.shields.io/badge/Roo_Code-555?style=flat-square" alt="Roo Code"></summary>
 
 Add to your Roo Code MCP config:
 ```json
 { "mcpServers": { "exa": { "type": "streamable-http", "url": "https://mcp.exa.ai/mcp" } } }
 ```
+</details>
 
-<h4 id="other-clients">Other Clients</h4>
+<details>
+<summary><img src="https://img.shields.io/badge/Other_Clients-888?style=flat-square" alt="Other Clients"></summary>
 
 For clients that support remote MCP:
 ```json
@@ -121,8 +148,10 @@ For clients that need mcp-remote:
 ```json
 { "mcpServers": { "exa": { "command": "npx", "args": ["-y", "mcp-remote", "https://mcp.exa.ai/mcp"] } } }
 ```
+</details>
 
-<h4 id="via-npm-package">Via npm Package</h4>
+<details>
+<summary><img src="https://img.shields.io/badge/npm_Package-CB3837?style=flat-square&logo=npm&logoColor=white" alt="npm Package"></summary>
 
 Use the npm package with your API key. [Get your API key](https://dashboard.exa.ai/api-keys).
 ```json
@@ -136,6 +165,7 @@ Use the npm package with your API key. [Get your API key](https://dashboard.exa.
   }
 }
 ```
+</details>
 
 ## Available Tools
 

--- a/README.md
+++ b/README.md
@@ -19,53 +19,79 @@ https://mcp.exa.ai/mcp
 
 [Get your API key](https://dashboard.exa.ai/api-keys)
 
-<table>
-<tr>
-<td><details><summary><b>Cursor</b></summary><br>
-Add to <code>~/.cursor/mcp.json</code>:
-<pre lang="json">{
+<details>
+<summary><b>Cursor</b> · <b>VS Code</b> · <b>Claude Code</b> · <b>Claude Desktop</b> · <b>Codex</b> · <b>OpenCode</b> · <b>Antigravity</b> · <b>Windsurf</b> · <b>Zed</b> · <b>Gemini CLI</b> · <b>v0</b> · <b>Warp</b> · <b>Kiro</b> · <b>Roo Code</b> · <b>Other Clients</b> · <b>npm Package</b></summary>
+
+### CLI
+
+```bash
+claude mcp add --transport http exa https://mcp.exa.ai/mcp   # Claude Code
+codex mcp add exa --url https://mcp.exa.ai/mcp               # Codex
+```
+
+### UI
+
+- **Antigravity** — MCP Store panel (from "..." dropdown) → add custom server → `https://mcp.exa.ai/mcp`
+- **v0 by Vercel** — Prompt Tools → Add MCP → `https://mcp.exa.ai/mcp`
+- **Warp** — Settings → MCP Servers → Add MCP Server → `{ "exa": { "url": "https://mcp.exa.ai/mcp" } }`
+
+### JSON Config
+
+Add to your client's config file:
+
+| Client | Config File |
+| ------ | ----------- |
+| Cursor | `~/.cursor/mcp.json` |
+| Kiro | `~/.kiro/settings/mcp.json` |
+
+```json
+{
   "mcpServers": {
     "exa": {
       "url": "https://mcp.exa.ai/mcp"
     }
   }
-}</pre>
-</details></td>
-<td><details><summary><b>VS Code</b></summary><br>
-Add to <code>.vscode/mcp.json</code>:
-<pre lang="json">{
+}
+```
+
+<details>
+<summary>VS Code</summary>
+
+Add to `.vscode/mcp.json`:
+```json
+{
   "servers": {
     "exa": {
       "type": "http",
       "url": "https://mcp.exa.ai/mcp"
     }
   }
-}</pre>
-</details></td>
-<td><details><summary><b>Claude Code</b></summary><br>
-<pre>claude mcp add --transport http exa https://mcp.exa.ai/mcp</pre>
-</details></td>
-<td><details><summary><b>Claude Desktop</b></summary><br>
-Config file:<br>
-<b>macOS:</b> <code>~/Library/Application Support/Claude/claude_desktop_config.json</code><br>
-<b>Windows:</b> <code>%APPDATA%\Claude\claude_desktop_config.json</code>
-<pre lang="json">{
+}
+```
+</details>
+
+<details>
+<summary>Claude Desktop</summary>
+
+Config file — **macOS:** `~/Library/Application Support/Claude/claude_desktop_config.json` · **Windows:** `%APPDATA%\Claude\claude_desktop_config.json`
+```json
+{
   "mcpServers": {
     "exa": {
       "command": "npx",
       "args": ["-y", "mcp-remote", "https://mcp.exa.ai/mcp"]
     }
   }
-}</pre>
-</details></td>
-</tr>
-<tr>
-<td><details><summary><b>Codex</b></summary><br>
-<pre>codex mcp add exa --url https://mcp.exa.ai/mcp</pre>
-</details></td>
-<td><details><summary><b>OpenCode</b></summary><br>
-Add to <code>opencode.json</code>:
-<pre lang="json">{
+}
+```
+</details>
+
+<details>
+<summary>OpenCode</summary>
+
+Add to `opencode.json`:
+```json
+{
   "mcp": {
     "exa": {
       "type": "remote",
@@ -73,101 +99,103 @@ Add to <code>opencode.json</code>:
       "enabled": true
     }
   }
-}</pre>
-</details></td>
-<td><details><summary><b>Antigravity</b></summary><br>
-Open the MCP Store panel (from the "..." dropdown in the side panel), then add a custom server with:
-<pre>https://mcp.exa.ai/mcp</pre>
-</details></td>
-<td><details><summary><b>Windsurf</b></summary><br>
-Add to <code>~/.codeium/windsurf/mcp_config.json</code>:
-<pre lang="json">{
+}
+```
+</details>
+
+<details>
+<summary>Windsurf</summary>
+
+Add to `~/.codeium/windsurf/mcp_config.json`:
+```json
+{
   "mcpServers": {
     "exa": {
       "serverUrl": "https://mcp.exa.ai/mcp"
     }
   }
-}</pre>
-</details></td>
-</tr>
-<tr>
-<td><details><summary><b>Zed</b></summary><br>
+}
+```
+</details>
+
+<details>
+<summary>Zed</summary>
+
 Add to your Zed settings:
-<pre lang="json">{
+```json
+{
   "context_servers": {
     "exa": {
       "url": "https://mcp.exa.ai/mcp"
     }
   }
-}</pre>
-</details></td>
-<td><details><summary><b>Gemini CLI</b></summary><br>
-Add to <code>~/.gemini/settings.json</code>:
-<pre lang="json">{
+}
+```
+</details>
+
+<details>
+<summary>Gemini CLI</summary>
+
+Add to `~/.gemini/settings.json`:
+```json
+{
   "mcpServers": {
     "exa": {
       "httpUrl": "https://mcp.exa.ai/mcp"
     }
   }
-}</pre>
-</details></td>
-<td><details><summary><b>v0 by Vercel</b></summary><br>
-In v0, select <b>Prompt Tools</b> &gt; <b>Add MCP</b> and enter:
-<pre>https://mcp.exa.ai/mcp</pre>
-</details></td>
-<td><details><summary><b>Warp</b></summary><br>
-Go to <b>Settings</b> &gt; <b>MCP Servers</b> &gt; <b>Add MCP Server</b> and add:
-<pre lang="json">{
-  "exa": {
-    "url": "https://mcp.exa.ai/mcp"
-  }
-}</pre>
-</details></td>
-</tr>
-<tr>
-<td><details><summary><b>Kiro</b></summary><br>
-Add to <code>~/.kiro/settings/mcp.json</code>:
-<pre lang="json">{
-  "mcpServers": {
-    "exa": {
-      "url": "https://mcp.exa.ai/mcp"
-    }
-  }
-}</pre>
-</details></td>
-<td><details><summary><b>Roo Code</b></summary><br>
+}
+```
+</details>
+
+<details>
+<summary>Roo Code</summary>
+
 Add to your Roo Code MCP config:
-<pre lang="json">{
+```json
+{
   "mcpServers": {
     "exa": {
       "type": "streamable-http",
       "url": "https://mcp.exa.ai/mcp"
     }
   }
-}</pre>
-</details></td>
-<td><details><summary><b>Other Clients</b></summary><br>
+}
+```
+</details>
+
+<details>
+<summary>Other Clients</summary>
+
 For clients that support remote MCP:
-<pre lang="json">{
+```json
+{
   "mcpServers": {
     "exa": {
       "url": "https://mcp.exa.ai/mcp"
     }
   }
-}</pre>
+}
+```
 For clients that need mcp-remote:
-<pre lang="json">{
+```json
+{
   "mcpServers": {
     "exa": {
       "command": "npx",
       "args": ["-y", "mcp-remote", "https://mcp.exa.ai/mcp"]
     }
   }
-}</pre>
-</details></td>
-<td><details><summary><b>Via npm Package</b></summary><br>
-Use the npm package with your API key. <a href="https://dashboard.exa.ai/api-keys">Get your API key</a>.
-<pre lang="json">{
+}
+```
+</details>
+
+<details>
+<summary>Via npm Package</summary>
+
+Use the npm package with your API key. [Get your API key](https://dashboard.exa.ai/api-keys).
+```json
+{
   "mcpServers": {
     "exa": {
       "command": "npx",
@@ -177,10 +205,11 @@ Use the npm package with your API key. <a href="https://dashboard.exa.ai/api-key
       }
     }
   }
-}</pre>
-</details></td>
-</tr>
-</table>
+}
+```
+</details>
+
+</details>
 
 ## Available Tools
 

--- a/README.md
+++ b/README.md
@@ -19,81 +19,53 @@ https://mcp.exa.ai/mcp
 
 [Get your API key](https://dashboard.exa.ai/api-keys)
 
-<details>
-<summary><b>Cursor</b></summary>
-
-Add to `~/.cursor/mcp.json`:
-
-```json
-{
+<table>
+<tr>
+<td><details><summary><b>Cursor</b></summary><br>
+Add to <code>~/.cursor/mcp.json</code>:
+<pre lang="json">{
   "mcpServers": {
     "exa": {
       "url": "https://mcp.exa.ai/mcp"
     }
   }
-}
-```
-</details>
-
-<details>
-<summary><b>VS Code</b></summary>
-
-Add to `.vscode/mcp.json`:
-
-```json
-{
+}</pre>
+</details></td>
+<td><details><summary><b>VS Code</b></summary><br>
+Add to <code>.vscode/mcp.json</code>:
+<pre lang="json">{
   "servers": {
     "exa": {
       "type": "http",
       "url": "https://mcp.exa.ai/mcp"
     }
   }
-}
-```
-</details>
-
-<details>
-<summary><b>Claude Code</b></summary>
-
-```bash
-claude mcp add --transport http exa https://mcp.exa.ai/mcp
-```
-</details>
-
-<details>
-<summary><b>Claude Desktop</b></summary>
-
-Add to your config file:
-- **macOS:** `~/Library/Application Support/Claude/claude_desktop_config.json`
-- **Windows:** `%APPDATA%\Claude\claude_desktop_config.json`
-
-```json
-{
+}</pre>
+</details></td>
+<td><details><summary><b>Claude Code</b></summary><br>
+<pre>claude mcp add --transport http exa https://mcp.exa.ai/mcp</pre>
+</details></td>
+<td><details><summary><b>Claude Desktop</b></summary><br>
+Config file:<br>
+<b>macOS:</b> <code>~/Library/Application Support/Claude/claude_desktop_config.json</code><br>
+<b>Windows:</b> <code>%APPDATA%\Claude\claude_desktop_config.json</code>
+<pre lang="json">{
   "mcpServers": {
     "exa": {
       "command": "npx",
       "args": ["-y", "mcp-remote", "https://mcp.exa.ai/mcp"]
     }
   }
-}
-```
-</details>
-
-<details>
-<summary><b>Codex</b></summary>
-
-```bash
-codex mcp add exa --url https://mcp.exa.ai/mcp
-```
-</details>
-
-<details>
-<summary><b>OpenCode</b></summary>
-
-Add to your `opencode.json`:
-
-```json
-{
+}</pre>
+</details></td>
+</tr>
+<tr>
+<td><details><summary><b>Codex</b></summary><br>
+<pre>codex mcp add exa --url https://mcp.exa.ai/mcp</pre>
+</details></td>
+<td><details><summary><b>OpenCode</b></summary><br>
+Add to <code>opencode.json</code>:
+<pre lang="json">{
   "mcp": {
     "exa": {
       "type": "remote",
@@ -101,161 +73,101 @@ Add to your `opencode.json`:
       "enabled": true
     }
   }
-}
-```
-</details>
-
-<details>
-<summary><b>Antigravity</b></summary>
-
+}</pre>
+</details></td>
+<td><details><summary><b>Antigravity</b></summary><br>
 Open the MCP Store panel (from the "..." dropdown in the side panel), then add a custom server with:
-
-```
-https://mcp.exa.ai/mcp
-```
-</details>
-
-<details>
-<summary><b>Windsurf</b></summary>
-
-Add to `~/.codeium/windsurf/mcp_config.json`:
-
-```json
-{
+<pre>https://mcp.exa.ai/mcp</pre>
+</details></td>
+<td><details><summary><b>Windsurf</b></summary><br>
+Add to <code>~/.codeium/windsurf/mcp_config.json</code>:
+<pre lang="json">{
   "mcpServers": {
     "exa": {
       "serverUrl": "https://mcp.exa.ai/mcp"
     }
   }
-}
-```
-</details>
-
-<details>
-<summary><b>Zed</b></summary>
-
+}</pre>
+</details></td>
+</tr>
+<tr>
+<td><details><summary><b>Zed</b></summary><br>
 Add to your Zed settings:
-
-```json
-{
+<pre lang="json">{
   "context_servers": {
     "exa": {
       "url": "https://mcp.exa.ai/mcp"
     }
   }
-}
-```
-</details>
-
-<details>
-<summary><b>Gemini CLI</b></summary>
-
-Add to `~/.gemini/settings.json`:
-
-```json
-{
+}</pre>
+</details></td>
+<td><details><summary><b>Gemini CLI</b></summary><br>
+Add to <code>~/.gemini/settings.json</code>:
+<pre lang="json">{
   "mcpServers": {
     "exa": {
       "httpUrl": "https://mcp.exa.ai/mcp"
     }
   }
-}
-```
-</details>
-
-<details>
-<summary><b>v0 by Vercel</b></summary>
-
-In v0, select **Prompt Tools** > **Add MCP** and enter:
-
-```
-https://mcp.exa.ai/mcp
-```
-</details>
-
-<details>
-<summary><b>Warp</b></summary>
-
-Go to **Settings** > **MCP Servers** > **Add MCP Server** and add:
-
-```json
-{
+}</pre>
+</details></td>
+<td><details><summary><b>v0 by Vercel</b></summary><br>
+In v0, select <b>Prompt Tools</b> &gt; <b>Add MCP</b> and enter:
+<pre>https://mcp.exa.ai/mcp</pre>
+</details></td>
+<td><details><summary><b>Warp</b></summary><br>
+Go to <b>Settings</b> &gt; <b>MCP Servers</b> &gt; <b>Add MCP Server</b> and add:
+<pre lang="json">{
   "exa": {
     "url": "https://mcp.exa.ai/mcp"
   }
-}
-```
-</details>
-
-<details>
-<summary><b>Kiro</b></summary>
-
-Add to `~/.kiro/settings/mcp.json`:
-
-```json
-{
+}</pre>
+</details></td>
+</tr>
+<tr>
+<td><details><summary><b>Kiro</b></summary><br>
+Add to <code>~/.kiro/settings/mcp.json</code>:
+<pre lang="json">{
   "mcpServers": {
     "exa": {
       "url": "https://mcp.exa.ai/mcp"
     }
   }
-}
-```
-</details>
-
-<details>
-<summary><b>Roo Code</b></summary>
-
+}</pre>
+</details></td>
+<td><details><summary><b>Roo Code</b></summary><br>
 Add to your Roo Code MCP config:
-
-```json
-{
+<pre lang="json">{
   "mcpServers": {
     "exa": {
       "type": "streamable-http",
       "url": "https://mcp.exa.ai/mcp"
     }
   }
-}
-```
-</details>
-
-<details>
-<summary><b>Other Clients</b></summary>
-
+}</pre>
+</details></td>
+<td><details><summary><b>Other Clients</b></summary><br>
 For clients that support remote MCP:
-
-```json
-{
+<pre lang="json">{
   "mcpServers": {
     "exa": {
       "url": "https://mcp.exa.ai/mcp"
     }
   }
-}
-```
-
+}</pre>
 For clients that need mcp-remote:
-
-```json
-{
+<pre lang="json">{
   "mcpServers": {
     "exa": {
       "command": "npx",
       "args": ["-y", "mcp-remote", "https://mcp.exa.ai/mcp"]
     }
   }
-}
-```
-</details>
-
-<details>
-<summary><b>Via npm Package</b></summary>
-
-Use the npm package with your API key. [Get your API key](https://dashboard.exa.ai/api-keys).
-
-```json
-{
+}</pre>
+</details></td>
+<td><details><summary><b>Via npm Package</b></summary><br>
+Use the npm package with your API key. <a href="https://dashboard.exa.ai/api-keys">Get your API key</a>.
+<pre lang="json">{
   "mcpServers": {
     "exa": {
       "command": "npx",
@@ -265,9 +177,10 @@ Use the npm package with your API key. [Get your API key](https://dashboard.exa.
       }
     }
   }
-}
-```
-</details>
+}</pre>
+</details></td>
+</tr>
+</table>
 
 ## Available Tools
 


### PR DESCRIPTION
## Summary

Condenses the 16 `<details>/<summary>` installation blocks by minifying multi-line JSON configs into single-line format and tightening instructional text. The collapsible structure and all config content is preserved — only formatting changed.

Changes:
- JSON configs condensed from multi-line (5-9 lines) to single-line format across all client sections
- Instructional text shortened (e.g., "Open the MCP Store panel (from the "..." dropdown in the side panel), then add a custom server with:" → inline arrow notation)
- Claude Desktop config paths condensed from bullet list to single line with `·` separator
- `env` block in npm Package section stays multi-line but inner object condensed

### Design evolution

Tried several approaches before settling on the simplest:
1. **4×4 HTML table grid** with `<details>` in `<td>` cells → layout shifts when expanding (buggy)
2. **Single outer `<details>`** grouping all clients by method → individual clients not discoverable
3. **Badge nav + anchor `<h4>` sections** → everything visible by default, more verbose than original
4. **Badge images in `<summary>`** → clicking badge navigated to image URL instead of toggling
5. **Minified JSON in existing `<details>` structure** (current) → same UX, ~50% fewer lines

## Review & Testing Checklist for Human

- [ ] **Spot-check minified JSON configs** — verify no keys/values were dropped during single-line condensation. High-risk configs: Claude Desktop (`mcp-remote` args array), OpenCode (`enabled: true`), Via npm Package (`env` block), Other Clients (two separate config blocks)
- [ ] **Readability judgment call** — single-line JSON is more compact but harder to scan/copy-paste. Decide if this tradeoff is acceptable or if multi-line should be restored for some configs
- [ ] **Verify rendered README on branch** — confirm all 16 `<details>` sections expand/collapse correctly and code blocks render with syntax highlighting

### Notes

- Requested by: @jeffzwang
- Devin session: https://app.devin.ai/sessions/c215486c09504513bce113c9b5336b03