### PR TITLE
feat(skills): add OpenClaw API-only Exa skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,6 +297,12 @@ https://mcp.exa.ai/mcp?tools=web_search_exa,web_search_advanced_exa,get_code_con
 
 Ready-to-use skills for Claude Code. Each skill teaches Claude how to use Exa search for a specific task. Copy the content inside a dropdown and paste it into Claude Code — it handles the rest.
 
+### Community Contributions
+
+- **OpenClaw API-only Exa skill (no MCP):**
+  - Skill files: [`skills/openclaw-exa-api/`](skills/openclaw-exa-api/)
+  - ClawHub: https://clawhub.ai/XieShaocong33Ethan/exa-full
+
 <details>
 <summary><b>Company Research</b></summary>
 

--- a/skills/openclaw-exa-api/EXAMPLES.md
+++ b/skills/openclaw-exa-api/EXAMPLES.md
@@ -1,0 +1,113 @@
+# Exa Skill Examples
+
+Use this file for concrete command patterns. Keep `SKILL.md` for execution rules and safety constraints.
+
+## Search Examples
+
+When to use: web lookup, entity discovery, domain-filtered search, people/company/news/paper workflows.
+
+```bash
+# Basic search
+bash scripts/search.sh "AI agents 2024"
+
+# Realtime UX / autocomplete
+TYPE=instant bash scripts/search.sh "best ramen near me open now"
+
+# High-quality general lookup
+TYPE=auto bash scripts/search.sh "latest AI model release notes"
+
+# Speed/quality balance
+TYPE=fast bash scripts/search.sh "top battery recycling companies europe"
+
+# Comprehensive search
+TYPE=deep bash scripts/search.sh "long-term impact of solid-state batteries on EV supply chain"
+
+# LinkedIn people search
+CATEGORY=people bash scripts/search.sh "software engineer Amsterdam"
+
+# Company search
+CATEGORY=company bash scripts/search.sh "fintech startup Netherlands"
+
+# Research paper search
+CATEGORY="research paper" bash scripts/search.sh "transformer architecture"
+
+# News from specific domains
+CATEGORY=news DOMAINS="reuters.com,bbc.com" bash scripts/search.sh "Netherlands"
+
+# Date-filtered news
+CATEGORY=news SINCE="2026-01-01" UNTIL="2026-02-01" bash scripts/search.sh "tech layoffs"
+```
+
+Notes:
+- With `CATEGORY=people`, `DOMAINS` only supports LinkedIn domains.
+- With `CATEGORY=people` or `CATEGORY=company`, avoid `EXCLUDE`, `SINCE`, and `UNTIL`.
+
+## Content Extraction and Crawling Examples
+
+When to use: pull full text from known URLs, summarize pages, crawl related docs pages.
+
+```bash
+# Extract one or more URLs
+bash scripts/content.sh "https://exa.ai/docs" "https://docs.exa.ai/"
+
+# Increase text budget for richer downstream reasoning
+MAX_CHARACTERS=10000 bash scripts/content.sh "https://exa.ai/docs/llms.txt" | jq
+
+# Crawl docs subpages from a seed URL
+SUBPAGES=10 SUBPAGE_TARGET="docs,reference,api" LIVECRAWL=preferred LIVECRAWL_TIMEOUT=12000 \
+  bash scripts/content.sh "https://docs.exa.ai/" | jq
+```
+
+Notes:
+- Prefer `https://docs.exa.ai/` as a crawl seed for docs subpages.
+- `LIVECRAWL` accepts `preferred`, `always`, or `fallback`.
+
+## Code Context Search Examples
+
+When to use: find API usage examples, implementation patterns, and doc/code snippets.
+
+```bash
+# Default result count (10)
+bash scripts/code.sh "Next.js partial prerendering config"
+
+# Explicit result count
+bash scripts/code.sh "Rust axum middleware auth example" 20
+```
+
+## Research Examples (Async)
+
+When to use: multi-source synthesis, citation-heavy research, or structured output requirements.
+
+### One-shot flow (create + poll)
+
+```bash
+bash scripts/research.sh "Compare the current flagship GPUs from NVIDIA, AMD, and Intel."
+```
+
+### One-shot with structured output
+
+```bash
+MODEL=exa-research-pro \
+SCHEMA_FILE="./schema.json" \
+POLL_INTERVAL=2 \
+MAX_WAIT_SECONDS=300 \
+EVENTS=true \
+bash scripts/research.sh "Estimate the global battery recycling market size in 2030 by region."
+```
+
+### Two-step flow (manual control)
+
+```bash
+# Create
+bash scripts/research_create.sh "Create a timeline of major OpenAI product releases from 2015 to 2023." | jq
+
+# Capture researchId
+RID="$(bash scripts/research_create.sh "Create a timeline of major OpenAI product releases from 2015 to 2023." | jq -r '.researchId')"
+
+# Poll
+bash scripts/research_poll.sh "$RID" | jq
+```
+
+Safety reminder:
+- `SCHEMA_FILE` contents are uploaded as `outputSchema`.
+- Never pass sensitive local files (for example: `.env`, private keys, certificate bundles, credential files).

--- a/skills/openclaw-exa-api/SKILL.md
+++ b/skills/openclaw-exa-api/SKILL.md
@@ -1,0 +1,137 @@
+---
+name: exa-full
+version: 1.2.1
+description: Exa AI search + Research API. Supports web/code search, content extraction, and async multi-step research tasks with outputSchema.
+homepage: https://exa.ai
+metadata: {"openclaw":{"emoji":"🔍","requires":{"bins":["curl","jq"],"env":["EXA_API_KEY"]}}}
+---
+
+# Exa - Search + Research
+
+Use this skill for web search, code-context search, URL content extraction, and async research workflows.
+
+## What This Skill Does
+
+- Run Exa web search with optional category and domain filters.
+- Retrieve full page content (and optional subpage crawling).
+- Find code and docs context for programming queries.
+- Run async research tasks (one-shot or create/poll workflows).
+- Support optional structured outputs via `outputSchema`.
+
+## Setup
+
+Set `EXA_API_KEY` using one of these methods.
+
+```bash
+export EXA_API_KEY="your-exa-api-key"
+```
+
+```bash
+# .env next to SKILL.md
+EXA_API_KEY=your-exa-api-key
+```
+
+Behavior:
+- If `EXA_API_KEY` is missing in the environment, scripts load only `EXA_API_KEY` from `.env`.
+- Other `.env` variables are ignored by the loader.
+
+## Safety and Data Handling
+
+- `SCHEMA_FILE` content is sent to `https://api.exa.ai/research/v1` as `outputSchema`.
+- Never use sensitive local files for `SCHEMA_FILE` (for example: `.env`, key/cert files, secrets, internal confidential docs).
+- `research_create.sh` blocks obvious sensitive paths/suffixes (for example: `.env`, `.pem`, `.key`, `.p12`, `.pfx`, `id_rsa`).
+
+## Command Quick Reference
+
+### Search
+
+```bash
+bash scripts/search.sh "query"
+```
+
+Main env vars:
+- `NUM=10` (max 100)
+- `TYPE=auto` (`auto`, `neural`, `fast`, `deep`, `instant`)
+- `CATEGORY=` (`company`, `research paper`, `news`, `tweet`, `personal site`, `financial report`, `people`)
+- `DOMAINS=domain1.com,domain2.com`
+- `EXCLUDE=domain1.com,domain2.com`
+- `SINCE=YYYY-MM-DD`
+- `UNTIL=YYYY-MM-DD`
+- `LOCATION=NL`
+
+Constraints:
+- `EXCLUDE` is not supported when `CATEGORY=company` or `CATEGORY=people`.
+- `SINCE` and `UNTIL` are not supported when `CATEGORY=company` or `CATEGORY=people`.
+- When `CATEGORY=people`, `DOMAINS` accepts LinkedIn domains only (`linkedin.com`, `www.linkedin.com`, `*.linkedin.com`).
+
+### Content Extraction
+
+```bash
+bash scripts/content.sh "url1" "url2"
+```
+
+Main env vars:
+- `MAX_CHARACTERS=2000`
+- `HIGHLIGHT_SENTENCES=3`
+- `HIGHLIGHTS_PER_URL=2`
+- `SUBPAGES=10`
+- `SUBPAGE_TARGET="docs,reference,api"`
+- `LIVECRAWL=preferred` (`preferred`, `always`, `fallback`)
+- `LIVECRAWL_TIMEOUT=12000`
+
+### Code Context Search
+
+```bash
+bash scripts/code.sh "query" [num_results]
+```
+
+### Research (One-shot)
+
+```bash
+bash scripts/research.sh "instructions"
+```
+
+Main env vars:
+- `MODEL=exa-research` or `MODEL=exa-research-pro`
+- `SCHEMA_FILE=path/to/schema.json`
+- `POLL_INTERVAL=2`
+- `MAX_WAIT_SECONDS=240`
+- `EVENTS=true`
+
+### Research (Create/Poll)
+
+```bash
+bash scripts/research_create.sh "instructions" | jq
+bash scripts/research_poll.sh "researchId" | jq
+```
+
+## Agent Decision Rules
+
+### Choose `TYPE` for Search
+
+Use this decision order:
+1. User explicitly asks for realtime or autocomplete -> `TYPE=instant`.
+2. Task needs broad coverage or deeper synthesis -> `TYPE=deep`.
+3. User asks for speed/quality balance -> `TYPE=fast`.
+4. Otherwise -> `TYPE=auto` (default).
+
+Fallback/escalation:
+- If too slow or time-sensitive: `deep -> auto -> fast -> instant`.
+- If too shallow: `instant -> fast -> auto -> deep`.
+- Explicit user requirement always wins.
+
+Recommended pattern:
+
+```bash
+TYPE=auto bash scripts/search.sh "query"
+```
+
+## Common Pitfalls
+
+- Do not pass sensitive files to `SCHEMA_FILE`.
+- Do not combine `CATEGORY=people|company` with `EXCLUDE`, `SINCE`, or `UNTIL`.
+- Prefer `https://docs.exa.ai/` for subpage crawling seeds (more reliable than `https://exa.ai/docs/reference/`).
+
+## More Examples
+
+See [EXAMPLES.md](EXAMPLES.md) for grouped command examples and edge-case workflows.


### PR DESCRIPTION
## Summary
- Add a new community-contributed skill at `skills/openclaw-exa-api/SKILL.md` using our existing `exa-full` skill content for OpenClaw users.
- Include `skills/openclaw-exa-api/EXAMPLES.md` so the skill's internal examples link remains valid.
- Update `README.md` with a community contribution entry linking the skill folder and ClawHub page.

## Why
OpenClaw prefers a direct API workflow without MCP, and this contribution adds a ready-to-use skill path while keeping Exa discoverable upstream.

## References
- ClawHub page: https://clawhub.ai/XieShaocong33Ethan/exa-full

## Test plan
- [x] Confirm new files are under `skills/openclaw-exa-api/`.
- [x] Confirm README renders with the new community section.
- [x] Confirm links are valid and all content is in English.
