### PR TITLE
[exa-mcp-server]: standardize textMaxCharacters and highlightsMaxCharacters across all tools

### DIFF
--- a/src/tools/crawling.ts
+++ b/src/tools/crawling.ts
@@ -15,14 +15,15 @@ Best for: Extracting content from a known URL.
 Returns: Full text content and metadata from the page.`,
     {
       url: z.string().describe("URL to crawl and extract content from"),
-      maxCharacters: z.coerce.number().optional().describe("Maximum characters to extract (must be a number, default: 3000)")
+      textMaxCharacters: z.coerce.number().optional().describe("Maximum characters for text content (must be a number, default: 2000)"),
+      highlightsMaxCharacters: z.coerce.number().optional().describe("Maximum characters for highlights per result (must be a number)")
     },
     {
       readOnlyHint: true,
       destructiveHint: false,
       idempotentHint: true
     },
-    async ({ url, maxCharacters }) => {
+    async ({ url, textMaxCharacters, highlightsMaxCharacters }) => {
       const requestId = `crawling_exa-${Date.now()}-${Math.random().toString(36).substring(2, 7)}`;
       const logger = createRequestLogger(requestId, 'crawling_exa');
       
@@ -45,8 +46,9 @@ Returns: Full text content and metadata from the page.`,
           ids: [url],
           contents: {
             text: {
-              maxCharacters: maxCharacters || API_CONFIG.DEFAULT_MAX_CHARACTERS
+              maxCharacters: textMaxCharacters || API_CONFIG.DEFAULT_MAX_CHARACTERS
             },
+            ...(highlightsMaxCharacters != null && { highlights: { maxCharacters: highlightsMaxCharacters } }),
             livecrawl: 'preferred'
           }
         };
@@ -121,4 +123,4 @@ Returns: Full text content and metadata from the page.`,
       }
     }
   );
-}                                                                                                
+}                                                                                                                                                                                                

--- a/src/tools/deepSearch.ts
+++ b/src/tools/deepSearch.ts
@@ -20,7 +20,8 @@ Note: Requires an Exa API key. 'deep' mode takes 4-12s, 'deep-reasoning' takes 1
       search_queries: z.array(z.string()).optional().describe("Optional list of keyword search queries related to the objective. Limited to 5 entries of up to 5 words each (~200 characters)."),
       type: z.enum(['deep', 'deep-reasoning']).optional().describe("Search depth - 'deep': fast deep search (4-12s, default), 'deep-reasoning': thorough with reasoning (12-50s)"),
       numResults: z.coerce.number().optional().describe("Number of search results to return (must be a number, default: 8)"),
-      highlightMaxCharacters: z.coerce.number().optional().describe("Maximum characters for highlights per result (must be a number, default: 4000)"),
+      textMaxCharacters: z.coerce.number().optional().describe("Maximum characters for text content per result (must be a number)"),
+      highlightsMaxCharacters: z.coerce.number().optional().describe("Maximum characters for highlights per result (must be a number, default: 4000)"),
       structuredOutput: z.boolean().optional().describe("When true, returns a structured JSON response instead of markdown. The API will determine the appropriate structure based on the query."),
     },
     {
@@ -28,7 +29,7 @@ Note: Requires an Exa API key. 'deep' mode takes 4-12s, 'deep-reasoning' takes 1
       destructiveHint: false,
       idempotentHint: false
     },
-    async ({ objective, search_queries, type, numResults, highlightMaxCharacters, structuredOutput }) => {
+    async ({ objective, search_queries, type, numResults, textMaxCharacters, highlightsMaxCharacters, structuredOutput }) => {
       const requestId = `deep_search_exa-${Date.now()}-${Math.random().toString(36).substring(2, 7)}`;
       const logger = createRequestLogger(requestId, 'deep_search_exa');
 
@@ -51,8 +52,9 @@ Note: Requires an Exa API key. 'deep' mode takes 4-12s, 'deep-reasoning' takes 1
           type: type || "deep",
           numResults: numResults || API_CONFIG.DEFAULT_NUM_RESULTS,
           contents: {
+            ...(textMaxCharacters != null && { text: { maxCharacters: textMaxCharacters } }),
             highlights: {
-              maxCharacters: highlightMaxCharacters || 4000
+              maxCharacters: highlightsMaxCharacters || 4000
             }
           }
         };

--- a/src/tools/webSearch.ts
+++ b/src/tools/webSearch.ts
@@ -20,6 +20,8 @@ Returns: Clean text content from top search results, ready for LLM use.`,
       livecrawl: z.enum(['fallback', 'preferred']).optional().describe("Live crawl mode - 'fallback': use live crawling as backup if cached content unavailable, 'preferred': prioritize live crawling (default: 'fallback')"),
       type: z.enum(['auto', 'fast']).optional().describe("Search type - 'auto': balanced search (default), 'fast': quick results"),
       category: z.enum(['company', 'research paper', 'people']).optional().describe("Filter results to a specific category - 'company': company websites and profiles, 'research paper': academic papers and research, 'people': LinkedIn profiles and personal bios"),
+      textMaxCharacters: z.coerce.number().optional().describe("Maximum characters for text content per result (must be a number)"),
+      highlightsMaxCharacters: z.coerce.number().optional().describe("Maximum characters for highlights per result (must be a number)"),
       contextMaxCharacters: z.coerce.number().optional().describe("Maximum characters for context string optimized for LLMs (must be a number, default: 10000)")
     },
     {
@@ -27,7 +29,7 @@ Returns: Clean text content from top search results, ready for LLM use.`,
       destructiveHint: false,
       idempotentHint: true
     },
-    async ({ query, numResults, livecrawl, type, category, contextMaxCharacters }) => {
+    async ({ query, numResults, livecrawl, type, category, textMaxCharacters, highlightsMaxCharacters, contextMaxCharacters }) => {
       const requestId = `web_search_exa-${Date.now()}-${Math.random().toString(36).substring(2, 7)}`;
       const logger = createRequestLogger(requestId, 'web_search_exa');
       
@@ -52,7 +54,8 @@ Returns: Clean text content from top search results, ready for LLM use.`,
           numResults: numResults || API_CONFIG.DEFAULT_NUM_RESULTS,
           ...(category && { category }),
           contents: {
-            text: true,
+            text: textMaxCharacters ? { maxCharacters: textMaxCharacters } : true,
+            ...(highlightsMaxCharacters != null && { highlights: { maxCharacters: highlightsMaxCharacters } }),
             context: {
               maxCharacters: contextMaxCharacters || 10000
             },
@@ -130,4 +133,4 @@ Returns: Clean text content from top search results, ready for LLM use.`,
       }
     }
   );
-}                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                
+}                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                

--- a/src/tools/webSearchAdvanced.ts
+++ b/src/tools/webSearchAdvanced.ts
@@ -46,6 +46,7 @@ Returns: Search results with optional highlights, summaries, and subpage content
       summaryQuery: z.string().optional().describe("Focus query for summary generation"),
 
       enableHighlights: z.boolean().optional().describe("Enable highlights extraction"),
+      highlightsMaxCharacters: z.coerce.number().optional().describe("Maximum characters for highlights per result (must be a number)"),
       highlightsNumSentences: z.coerce.number().optional().describe("Number of sentences per highlight (must be a number)"),
       highlightsPerUrl: z.coerce.number().optional().describe("Number of highlights per URL (must be a number)"),
       highlightsQuery: z.string().optional().describe("Query for highlight relevance"),
@@ -98,6 +99,7 @@ Returns: Search results with optional highlights, summaries, and subpage content
 
         if (params.enableHighlights) {
           contents.highlights = {
+            maxCharacters: params.highlightsMaxCharacters,
             numSentences: params.highlightsNumSentences,
             highlightsPerUrl: params.highlightsPerUrl,
             query: params.highlightsQuery,

--- a/src/types.ts
+++ b/src/types.ts
@@ -14,6 +14,12 @@ export interface ExaSearchRequest {
     text?: {
       maxCharacters?: number;
     } | boolean;
+    highlights?: {
+      maxCharacters?: number;
+      numSentences?: number;
+      highlightsPerUrl?: number;
+      query?: string;
+    };
     context?: {
       maxCharacters?: number;
     } | boolean;
@@ -53,6 +59,7 @@ export interface ExaAdvancedSearchRequest {
       query?: string;
     } | boolean;
     highlights?: {
+      maxCharacters?: number;
       numSentences?: number;
       highlightsPerUrl?: number;
       query?: string;
@@ -112,6 +119,9 @@ export interface ExaDeepSearchRequest {
   additionalQueries?: string[];
   outputSchema?: Record<string, unknown>;
   contents: {
+    text?: {
+      maxCharacters?: number;
+    } | boolean;
     highlights?: {
       maxCharacters?: number;
       numSentences?: number;


### PR DESCRIPTION
# Standardize textMaxCharacters and highlightsMaxCharacters across tools

## Summary

All search/crawl tools now expose a consistent pair of content-length params: `textMaxCharacters` and `highlightsMaxCharacters`.

| Tool | Before | After |
|------|--------|-------|
| `web_search_exa` | `contextMaxCharacters` only | + `textMaxCharacters`, `highlightsMaxCharacters` |
| `deep_search_exa` | `highlightMaxCharacters` (singular) | renamed → `highlightsMaxCharacters`, + `textMaxCharacters` |
| `crawling_exa` | `maxCharacters` | renamed → `textMaxCharacters`, + `highlightsMaxCharacters` |
| `web_search_advanced_exa` | `textMaxCharacters` ✅, highlights had no maxCharacters | + `highlightsMaxCharacters` |

Type definitions updated to match (`ExaSearchRequest`, `ExaAdvancedSearchRequest`, `ExaDeepSearchRequest`).

## Review & Testing Checklist for Human

- [ ] **Breaking param renames** — `crawling_exa.maxCharacters` → `textMaxCharacters` and `deep_search_exa.highlightMaxCharacters` → `highlightsMaxCharacters` are breaking changes for existing MCP clients. Verify no critical downstream callers depend on the old names, or consider keeping old names as aliases.
- [ ] **webSearch highlights are requested but not surfaced** — when `highlightsMaxCharacters` is set on `web_search_exa`, highlights are sent to the API but the handler only returns `response.data.context`, not individual result highlights. Confirm this is acceptable or if the response format should change.
- [ ] **Test with a real MCP client** (Cursor/Claude Desktop) — call each of the 4 modified tools with the new params and verify the Exa API accepts them without errors and returns expected content shapes.

### Notes
- `contextMaxCharacters` on `web_search_exa` is preserved (not renamed) since it controls a different content mode.
- New params are all optional with no forced defaults (except where defaults already existed: crawling text=2000, deepSearch highlights=4000).

Requested by: @JakubHojsan
[Devin Session](https://app.devin.ai/sessions/739e7e147d5049b09eccdc46d9295c98)