### PR TITLE
[people-search]: reduce MCP token output via context API

### DIFF
--- a/src/tools/peopleSearch.ts
+++ b/src/tools/peopleSearch.ts
@@ -16,14 +16,15 @@ Best for: Finding professionals, executives, or anyone with a public profile.
 Returns: Profile information and links.`,
     {
       query: z.string().describe("Search query for finding people"),
-      numResults: z.coerce.number().optional().describe("Number of profile results to return (must be a number, default: 5)")
+      numResults: z.coerce.number().optional().describe("Number of profile results to return (must be a number, default: 5)"),
+      contextMaxCharacters: z.coerce.number().optional().describe("Maximum characters for context string optimized for LLMs (must be a number, default: 8000)")
     },
     {
       readOnlyHint: true,
       destructiveHint: false,
       idempotentHint: true
     },
-    async ({ query, numResults }) => {
+    async ({ query, numResults, contextMaxCharacters }) => {
       const requestId = `people_search_exa-${Date.now()}-${Math.random().toString(36).substring(2, 7)}`;
       const logger = createRequestLogger(requestId, 'people_search_exa');
       
@@ -52,7 +53,10 @@ Returns: Profile information and links.`,
           category: "people",
           contents: {
             text: {
-              maxCharacters: API_CONFIG.DEFAULT_MAX_CHARACTERS
+              maxCharacters: 500
+            },
+            context: {
+              maxCharacters: contextMaxCharacters || 8000
             },
           },
         };
@@ -81,11 +85,24 @@ Returns: Profile information and links.`,
         }
 
         logger.log(`Found ${response.data.results.length} results`);
-        
+
+        const profiles = response.data.results.map(r => ({
+          title: r.title,
+          url: r.url,
+          author: r.author,
+          ...(r.text && { text: r.text }),
+        }));
+
+        const parts: string[] = [];
+        if (response.data.context) {
+          parts.push(response.data.context);
+        }
+        parts.push(JSON.stringify(profiles));
+
         const result = {
           content: [{
             type: "text" as const,
-            text: JSON.stringify(response.data, null, 2)
+            text: parts.join("\n\n")
           }]
         };
         


### PR DESCRIPTION
## Summary

Reduces token output from `people_search_exa` MCP tool (~15-17k tokens → significantly less) by:

1. **Using the `context` API** — returns an LLM-optimized summary string instead of dumping the entire raw API response via `JSON.stringify(response.data, null, 2)`
2. **Stripping results to essential fields** — only `title`, `url`, `author`, and truncated `text` (500 chars, down from 2000)
3. **Adding `contextMaxCharacters` parameter** — lets callers control context size (default: 8000)

Mirrors the pattern already used by `web_search_exa`, which returns `response.data.context` instead of raw JSON.

## Review & Testing Checklist for Human

- [ ] **Verify `context` works well with `category: "people"` queries** — if the API returns `context: null/undefined` for people searches, the output degrades to just the stripped profiles array (no summary). Test a few people queries and confirm context is populated.
- [ ] **Check if 500 chars of `text` per result is sufficient** — reduced from 2000 (`DEFAULT_MAX_CHARACTERS`). Previously configurable via the constant, now hardcoded. May want to make this a parameter or bump it up.
- [ ] **Breaking change for existing consumers** — output format changed from pretty-printed full JSON to `context + compact profiles JSON`. Anyone parsing the old JSON structure will break.

**Suggested test plan:** Run `people_search_exa` with a query like `"Exa.ai employee engineer 2024"` with `numResults: 10` and compare token count before/after. Verify the context string contains useful profile summaries and the structured profiles array has the key fields.

### Notes
- `companyResearch.ts` has the same `JSON.stringify(response.data, null, 2)` pattern but was not changed (out of scope)
- Requested by @JakubHojsan
- [Devin session](https://app.devin.ai/sessions/1f59c93fab074df4bb72431a68895cb4)