### PR TITLE
[deep-search]: add outputSchema and systemPrompt params to deep_search_exa

### DIFF
--- a/src/tools/deepSearch.ts
+++ b/src/tools/deepSearch.ts
@@ -22,7 +22,7 @@ Note: Requires an Exa API key. 'deep' mode takes 4-12s, 'deep-reasoning' takes 1
       numResults: z.coerce.number().optional().describe("Number of search results to return (must be a number, default: 8)"),
       highlightMaxCharacters: z.coerce.number().optional().describe("Maximum characters for highlights per result (must be a number, default: 4000)"),
       outputSchema: z.record(z.string(), z.unknown()).optional().describe("JSON schema for structured output. When provided, the API returns a structured JSON response matching this schema. Automatically enables structured output mode."),
-      systemPrompt: z.string().optional().describe("Instructions for how the deep search agent should process and format results. Max 32,000 characters."),
+      systemPrompt: z.string().max(32000).optional().describe("Instructions for how the deep search agent should process and format results."),
       structuredOutput: z.boolean().optional().describe("When true, returns a structured JSON response instead of markdown. The API will determine the appropriate structure based on the query. Prefer using outputSchema for more control over the response shape."),
     },
     {

--- a/src/tools/deepSearch.ts
+++ b/src/tools/deepSearch.ts
@@ -21,7 +21,7 @@ Note: Requires an Exa API key. 'deep' mode takes 4-12s, 'deep-reasoning' takes 1
       type: z.enum(['deep', 'deep-reasoning']).optional().describe("Search depth - 'deep': fast deep search (4-12s, default), 'deep-reasoning': thorough with reasoning (12-50s)"),
       numResults: z.coerce.number().optional().describe("Number of search results to return (must be a number, default: 8)"),
       highlightMaxCharacters: z.coerce.number().optional().describe("Maximum characters for highlights per result (must be a number, default: 4000)"),
-      outputSchema: z.record(z.string(), z.unknown()).optional().describe("JSON schema for structured output. When provided, the API returns a structured JSON response matching this schema. Automatically enables structured output mode."),
+      outputSchema: z.record(z.string(), z.unknown()).optional().describe("JSON schema for structured output. Must include a 'type' field set to 'object' or 'text'. For 'object' type, optionally include 'properties' and 'required'. Max 10 total properties, max nesting depth 2. When provided, automatically enables structured output mode."),
       systemPrompt: z.string().max(32000).optional().describe("Instructions for how the deep search agent should process and format results."),
       structuredOutput: z.boolean().optional().describe("When true, returns a structured JSON response instead of markdown. The API will determine the appropriate structure based on the query. Prefer using outputSchema for more control over the response shape."),
     },

--- a/src/tools/deepSearch.ts
+++ b/src/tools/deepSearch.ts
@@ -21,14 +21,16 @@ Note: Requires an Exa API key. 'deep' mode takes 4-12s, 'deep-reasoning' takes 1
       type: z.enum(['deep', 'deep-reasoning']).optional().describe("Search depth - 'deep': fast deep search (4-12s, default), 'deep-reasoning': thorough with reasoning (12-50s)"),
       numResults: z.coerce.number().optional().describe("Number of search results to return (must be a number, default: 8)"),
       highlightMaxCharacters: z.coerce.number().optional().describe("Maximum characters for highlights per result (must be a number, default: 4000)"),
-      structuredOutput: z.boolean().optional().describe("When true, returns a structured JSON response instead of markdown. The API will determine the appropriate structure based on the query."),
+      outputSchema: z.record(z.string(), z.unknown()).optional().describe("JSON schema for structured output. When provided, the API returns a structured JSON response matching this schema. Automatically enables structured output mode."),
+      systemPrompt: z.string().optional().describe("Instructions for how the deep search agent should process and format results. Max 32,000 characters."),
+      structuredOutput: z.boolean().optional().describe("When true, returns a structured JSON response instead of markdown. The API will determine the appropriate structure based on the query. Prefer using outputSchema for more control over the response shape."),
     },
     {
       readOnlyHint: true,
       destructiveHint: false,
       idempotentHint: false
     },
-    async ({ objective, search_queries, type, numResults, highlightMaxCharacters, structuredOutput }) => {
+    async ({ objective, search_queries, type, numResults, highlightMaxCharacters, outputSchema, systemPrompt, structuredOutput }) => {
       const requestId = `deep_search_exa-${Date.now()}-${Math.random().toString(36).substring(2, 7)}`;
       const logger = createRequestLogger(requestId, 'deep_search_exa');
 
@@ -57,9 +59,17 @@ Note: Requires an Exa API key. 'deep' mode takes 4-12s, 'deep-reasoning' takes 1
           }
         };
 
-        if (structuredOutput) {
+        if (outputSchema) {
+          searchRequest.outputSchema = outputSchema;
+          logger.log("Using custom output schema");
+        } else if (structuredOutput) {
           searchRequest.outputSchema = { type: "object" };
-          logger.log("Using structured output");
+          logger.log("Using default structured output");
+        }
+
+        if (systemPrompt) {
+          searchRequest.systemPrompt = systemPrompt;
+          logger.log("Using system prompt");
         }
 
         if (search_queries && search_queries.length > 0) {
@@ -94,8 +104,8 @@ Note: Requires an Exa API key. 'deep' mode takes 4-12s, 'deep-reasoning' takes 1
 
         const data = response.data;
 
-        // When structured output was requested, return the raw JSON response
-        if (structuredOutput) {
+        // When structured output was requested (via outputSchema or structuredOutput flag), return the raw JSON response
+        if (outputSchema || structuredOutput) {
           const structuredResponse = {
             output: data.output,
             results: data.results,

--- a/src/types.ts
+++ b/src/types.ts
@@ -111,6 +111,7 @@ export interface ExaDeepSearchRequest {
   numResults?: number;
   additionalQueries?: string[];
   outputSchema?: Record<string, unknown>;
+  systemPrompt?: string;
   contents: {
     highlights?: {
       maxCharacters?: number;


### PR DESCRIPTION
## Summary

Exposes `outputSchema` and `systemPrompt` as first-class params on the `deep_search_exa` MCP tool. Previously, structured output was limited to `structuredOutput: true` which hardcoded `outputSchema: { type: "object" }` — no way to pass a custom JSON schema or system prompt.

**Changes:**
- `outputSchema` (optional object) — custom JSON schema passed through to the Exa API. Description documents API constraints: must include `type` field (`"object"` or `"text"`), max 10 total properties, max nesting depth 2. When provided, automatically returns structured JSON response.
- `systemPrompt` (optional string, max 32k chars) — instructions forwarded to the deep search agent. Zod-enforced `.max(32000)` to match Vulcan's server-side limit.
- `structuredOutput` boolean preserved for backward compat — if `true` and no `outputSchema` given, falls back to `{ type: "object" }` default.
- Added `systemPrompt` to `ExaDeepSearchRequest` type (`outputSchema` was already there).

**Validation approach:** MCP accepts any object via `z.record(z.string(), z.unknown())` and lets the API enforce the discriminated union / property limits. This avoids duplicating Vulcan's validation logic. Invalid schemas get a clear 400 error from the API (e.g. `"Output_schema exceeds maximum of 10 properties"`).

## API Verification (curl, not through MCP)

All three API behaviors were verified live against `https://api.exa.ai/search`:

1. **`outputSchema` passthrough** — sent `{ type: "object", properties: { companies: { type: "array", items: { ... } } } }` → API returned structured JSON with `companies` array matching the schema, with per-field grounding citations. ✓
2. **`systemPrompt`** — sent `"You are a senior software architect. Return a numbered list of exactly 3 languages..."` → output followed the instruction exactly. ✓
3. **Backward compat** — sent `outputSchema: { type: "object" }` (the default when `structuredOutput: true`) → returned structured JSON as before. ✓

### Edge case testing (curl against live API)

| Input | API Response |
|---|---|
| >10 properties | 400: `"Output_schema exceeds maximum of 10 properties"` |
| >2 nesting depth | 400: `"Output_schema exceeds maximum nesting depth of 2"` |
| Invalid type (`"invalid_type"`) | 400: `"Invalid input at outputSchema.type"` |
| Missing type (`{}`) | 400: `"Invalid input at outputSchema.type"` |
| String instead of object | 400: `"expected object, received string"` |
| Array instead of object | 400: `"expected object, received array"` |
| `null` | Silently ignored (no schema applied) |
| `{ type: "text" }` | ✓ Returns text output |
| `{ type: "object" }` (no properties) | ✓ API auto-infers structure |

## Review & Testing Checklist for Human

- [ ] **Test through actual MCP invocation**: All API verification was done via curl, not through the full MCP tool path (zod parsing → request construction → response handling). Recommend running via MCP inspector (`npm run inspector`) or a real MCP client (Claude Desktop, Cursor) to confirm end-to-end behavior — especially that `outputSchema` objects survive zod parsing intact.
- [ ] **Verify error UX for invalid schemas**: When the API rejects an invalid `outputSchema`, the error flows through the axios handler as `"Deep search error (400): <message>"`. Confirm this is surfaced clearly to the MCP client and not swallowed.
- [ ] **Confirm `outputSchema` takes priority over `structuredOutput`**: When both are provided, `outputSchema` should win. This is the implemented logic but was not explicitly tested end-to-end.

### Notes
- Requested by @scottlangille
- [Devin session](https://app.devin.ai/sessions/d0bba67057d54f64adf29de9a9b7db1c)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/exa-labs/exa-mcp-server/pull/206" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
