### PR TITLE
[web-search-advanced]: add highlightsMaxCharacters, deprecate numSentences/highlightsPerUrl

### DIFF
--- a/src/tools/webSearchAdvanced.ts
+++ b/src/tools/webSearchAdvanced.ts
@@ -46,8 +46,9 @@ Returns: Search results with optional highlights, summaries, and subpage content
       summaryQuery: z.string().optional().describe("Focus query for summary generation"),
 
       enableHighlights: z.boolean().optional().describe("Enable highlights extraction"),
-      highlightsNumSentences: z.coerce.number().optional().describe("Number of sentences per highlight (must be a number)"),
-      highlightsPerUrl: z.coerce.number().optional().describe("Number of highlights per URL (must be a number)"),
+      highlightsMaxCharacters: z.coerce.number().optional().describe("Maximum total characters across all highlights per URL (must be a number). Preferred over highlightsNumSentences."),
+      highlightsNumSentences: z.coerce.number().optional().describe("Deprecated: mapped to ~1333 chars/sentence. Use highlightsMaxCharacters instead."),
+      highlightsPerUrl: z.coerce.number().optional().describe("Deprecated: currently ignored server-side. Use highlightsMaxCharacters instead."),
       highlightsQuery: z.string().optional().describe("Query for highlight relevance"),
 
       livecrawl: z.enum(['never', 'fallback', 'always', 'preferred']).optional().describe("Live crawl mode - 'never': only cached, 'fallback': cached then live, 'always': always live, 'preferred': prefer live (default: 'fallback')"),
@@ -98,6 +99,7 @@ Returns: Search results with optional highlights, summaries, and subpage content
 
         if (params.enableHighlights) {
           contents.highlights = {
+            maxCharacters: params.highlightsMaxCharacters,
             numSentences: params.highlightsNumSentences,
             highlightsPerUrl: params.highlightsPerUrl,
             query: params.highlightsQuery,

--- a/src/types.ts
+++ b/src/types.ts
@@ -53,6 +53,7 @@ export interface ExaAdvancedSearchRequest {
       query?: string;
     } | boolean;
     highlights?: {
+      maxCharacters?: number;
       numSentences?: number;
       highlightsPerUrl?: number;
       query?: string;


### PR DESCRIPTION
# [web-search-advanced]: add highlightsMaxCharacters, deprecate legacy highlight params

## Summary

Aligns the `web_search_advanced_exa` MCP tool with the current Exa API spec for highlights. The API now prefers `maxCharacters` over the legacy `numSentences`/`highlightsPerUrl` params — `numSentences` is mapped to a character budget (~1333 chars/sentence) and `highlightsPerUrl` is silently ignored server-side.

Changes:
- Add `highlightsMaxCharacters` param to tool schema and wire it through as `highlights.maxCharacters` in the API request
- Add `maxCharacters` to `ExaAdvancedSearchRequest` type
- Mark `highlightsNumSentences` and `highlightsPerUrl` descriptions as deprecated

Non-breaking: deprecated params are still forwarded to the API as before.

## Review & Testing Checklist for Human
- [ ] Verify that when `highlightsMaxCharacters` is passed alongside `enableHighlights: true`, the API response returns highlights respecting the character budget
- [ ] Verify that passing only the deprecated `highlightsNumSentences` still works (backward compat)

### Notes
- Requested by: @JakubHojsan
- [Devin session](https://app.devin.ai/sessions/342066cf2c904d319a3151f2a5cd35ef)