### PR TITLE
fix: output binaries to build directory for npx compatibility

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "zod": "^3.22.4"
       },
       "bin": {
-        "exa-mcp-server": ".smithery/stdio/index.cjs"
+        "exa-mcp-server": "build/stdio/index.cjs"
       },
       "devDependencies": {
         "@smithery/cli": "^1.4.4",

--- a/package.json
+++ b/package.json
@@ -10,10 +10,10 @@
     "url": "git+https://github.com/exa-labs/exa-mcp-server.git"
   },
   "bin": {
-    "exa-mcp-server": ".smithery/stdio/index.cjs"
+    "exa-mcp-server": "build/stdio/index.cjs"
   },
   "files": [
-    ".smithery"
+    ".smithery", "build"
   ],
   "keywords": [
     "mcp",
@@ -31,8 +31,8 @@
   "author": "Exa Labs",
   "scripts": {
     "build": "npm run build:shttp && npm run build:stdio",
-    "build:stdio": "smithery build src/index.ts --transport stdio -o .smithery/stdio/index.cjs && echo '#!/usr/bin/env node' | cat - .smithery/stdio/index.cjs > temp && mv temp .smithery/stdio/index.cjs && chmod +x .smithery/stdio/index.cjs",
-    "build:shttp": "smithery build src/index.ts --transport shttp -o .smithery/shttp/index.cjs",
+    "build:stdio": "smithery build src/index.ts --transport stdio -o build/stdio/index.cjs && echo '#!/usr/bin/env node' | cat - build/stdio/index.cjs > temp && mv temp build/stdio/index.cjs && chmod +x build/stdio/index.cjs",
+    "build:shttp": "smithery build src/index.ts --transport shttp -o build/shttp/index.cjs",
     "build:vercel": "npm install typescript && ./node_modules/.bin/tsc",
     "prepare": "npm run build:stdio",
     "watch": "./node_modules/.bin/tsc --watch",


### PR DESCRIPTION
## Summary
When running `npx -y exa-mcp-server` in a local environment (such as Claude Desktop or Cursor), execution can fail because `npm` has trouble linking or determining the executable if it resides in a hidden directory (like `.smithery`).

## Problem
Closes #107

## Solution
Updated the `build:stdio` and `build:shttp` scripts to output the compiled files to `build/` instead of `.smithery/`. Also updated the `bin` field and `files` array in `package.json` accordingly. This enables `npx` to properly find and run the entry point for standard MCP connections.