### PR TITLE
fix: output binaries to build directory for npx compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,10 +10,10 @@
     "url": "git+https://github.com/exa-labs/exa-mcp-server.git"
   },
   "bin": {
-    "exa-mcp-server": ".smithery/stdio/index.cjs"
+    "exa-mcp-server": "build/index.cjs"
   },
   "files": [
-    ".smithery"
+    "build"
   ],
   "keywords": [
     "mcp",
@@ -31,8 +31,8 @@
   "author": "Exa Labs",
   "scripts": {
     "build": "npm run build:shttp && npm run build:stdio",
-    "build:stdio": "smithery build src/index.ts --transport stdio -o .smithery/stdio/index.cjs && echo '#!/usr/bin/env node' | cat - .smithery/stdio/index.cjs > temp && mv temp .smithery/stdio/index.cjs && chmod +x .smithery/stdio/index.cjs",
-    "build:shttp": "smithery build src/index.ts --transport shttp -o .smithery/shttp/index.cjs",
+    "build:stdio": "smithery build src/index.ts --transport stdio -o build/index.cjs && echo '#!/usr/bin/env node' | cat - build/index.cjs > temp && mv temp build/index.cjs && chmod +x build/index.cjs",
+    "build:shttp": "smithery build src/index.ts --transport shttp -o build/shttp/index.cjs",
     "build:vercel": "npm install typescript && ./node_modules/.bin/tsc",
     "prepare": "npm run build:stdio",
     "watch": "./node_modules/.bin/tsc --watch",


### PR DESCRIPTION
## Summary
Moves the built executable output from the hidden `.smithery` directory to a standard `build` directory.

## Problem
Fixes #107. 
Running `npx -y exa-mcp-server` fails on local stdio connections because npm struggles to correctly symlink binaries located inside dot-prefixed (hidden) directories into `node_modules/.bin/`.

## Solution
Updated the `package.json` scripts to output to `build/index.cjs` and `build/shttp/index.cjs`, changed the `bin` pointing field to `build/index.cjs`, and updated the `files` array to include the new `build` directory instead of `.smithery`. This adheres to standard NPM packaging conventions and ensures `npx` properly locates the executable.