### PR TITLE
Deprecate redundant tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,17 +280,12 @@ Use the npm package with your API key. [Get your API key](https://dashboard.exa.
 | Tool | Description |
 | ---- | ----------- |
 | `web_search_advanced_exa` | Advanced web search with full control over filters, domains, dates, and content options |
-| `company_research_exa` | Research any company to get business information, news, and insights |
 | `crawling_exa` | Get the full content of a specific webpage from a known URL |
-| `people_search_exa` | Find people and their professional profiles |
-| `deep_researcher_start` | Start an AI research agent that searches, reads, and writes a detailed report |
-| `deep_researcher_check` | Check status and get results from a deep research task |
-| `deep_search_exa` | Deep search with query expansion and synthesized answers. Requires your own API key — it will not appear in the tools list without one. |
 
-Enable all tools with the `tools` parameter:
+Enable additional tools with the `tools` parameter:
 
 ```
-https://mcp.exa.ai/mcp?exaApiKey=YOUR_KEY&tools=web_search_exa,web_search_advanced_exa,get_code_context_exa,crawling_exa,company_research_exa,people_search_exa,deep_researcher_start,deep_researcher_check,deep_search_exa
+https://mcp.exa.ai/mcp?exaApiKey=YOUR_KEY&tools=web_search_exa,web_search_advanced_exa,get_code_context_exa,crawling_exa
 ```
 
 ## Agent Skills (Claude Skills)

--- a/api/well-known-mcp-config.ts
+++ b/api/well-known-mcp-config.ts
@@ -11,11 +11,6 @@ const AVAILABLE_TOOLS = [
   'web_search_advanced_exa',
   'get_code_context_exa',
   'crawling_exa',
-  'deep_researcher_start',
-  'deep_researcher_check',
-  'people_search_exa',
-  'linkedin_search_exa', // Deprecated: use people_search_exa
-  'company_research_exa',
 ];
 
 const configSchema = {
@@ -36,8 +31,8 @@ const configSchema = {
       "title": "Enabled Tools",
       "description": "Comma-separated list of tools to enable. Leave empty for defaults (web_search_exa, get_code_context_exa).",
       "examples": [
-        "web_search_exa,crawling_exa",
-        "web_search_exa,crawling_exa,company_research_exa"
+        "web_search_exa,web_search_advanced_exa",
+        "web_search_exa,web_search_advanced_exa,get_code_context_exa"
       ],
       "x-available-values": AVAILABLE_TOOLS
     },

--- a/server.json
+++ b/server.json
@@ -13,7 +13,7 @@
   "remotes": [
     {
       "type": "sse",
-      "url": "https://mcp.exa.ai/mcp?tools=web_search_exa,web_search_advanced_exa,get_code_context_exa,crawling_exa,company_research_exa,people_search_exa,linkedin_search_exa,deep_researcher_start,deep_researcher_check",
+      "url": "https://mcp.exa.ai/mcp?tools=web_search_exa,web_search_advanced_exa,get_code_context_exa,crawling_exa",
       "description": "Hosted Exa MCP server with web search and web crawling capabilities. Get the API key from https://dashboard.exa.ai/api-keys. Customize the tools parameter to enable only specific tools (comma-separated list)."
     }
   ]

--- a/smithery-example.json
+++ b/smithery-example.json
@@ -2,11 +2,9 @@
   "exaApiKey": "your-exa-api-key-here",
   "enabledTools": [
     "web_search_exa",
-    "company_research_exa",
-    "crawling_exa",
-    "people_search_exa",
-    "deep_researcher_start",
-    "deep_researcher_check"
+    "web_search_advanced_exa",
+    "get_code_context_exa",
+    "crawling_exa"
   ],
   "debug": false
-} 
+}

--- a/src/mcp-handler.ts
+++ b/src/mcp-handler.ts
@@ -19,13 +19,13 @@ const availableTools = {
   'web_search_exa': { name: 'Web Search (Exa)', description: 'Real-time web search using Exa AI', enabled: true },
   'web_search_advanced_exa': { name: 'Advanced Web Search (Exa)', description: 'Advanced web search with full Exa API control including category filters, domain restrictions, date ranges, highlights, summaries, and subpage crawling', enabled: false },
   'get_code_context_exa': { name: 'Code Context Search', description: 'Search for code snippets, examples, and documentation from open source repositories', enabled: true },
-  'company_research_exa': { name: 'Company Research', description: 'Research companies and organizations', enabled: false },
+  'company_research_exa': { name: 'Company Research (Deprecated)', description: 'Deprecated: Use web_search_advanced_exa instead. Research companies and organizations', enabled: false },
   'crawling_exa': { name: 'Web Crawling', description: 'Extract content from specific URLs', enabled: false },
-  'deep_researcher_start': { name: 'Deep Researcher Start', description: 'Start a comprehensive AI research task', enabled: false },
-  'deep_researcher_check': { name: 'Deep Researcher Check', description: 'Check status and retrieve results of research task', enabled: false },
-  'people_search_exa': { name: 'People Search', description: 'Search for people and professional profiles', enabled: false },
-  'linkedin_search_exa': { name: 'LinkedIn Search (Deprecated)', description: 'Deprecated: Use people_search_exa instead', enabled: false },
-  'deep_search_exa': { name: 'Deep Search', description: 'Deep search with query expansion and synthesized answers (requires API key)', enabled: false },
+  'deep_researcher_start': { name: 'Deep Researcher Start (Deprecated)', description: 'Deprecated: Start a comprehensive AI research task', enabled: false },
+  'deep_researcher_check': { name: 'Deep Researcher Check (Deprecated)', description: 'Deprecated: Check status and retrieve results of research task', enabled: false },
+  'people_search_exa': { name: 'People Search (Deprecated)', description: 'Deprecated: Use web_search_advanced_exa instead. Search for people and professional profiles', enabled: false },
+  'linkedin_search_exa': { name: 'LinkedIn Search (Deprecated)', description: 'Deprecated: Use web_search_advanced_exa instead', enabled: false },
+  'deep_search_exa': { name: 'Deep Search (Deprecated)', description: 'Deprecated: Use web_search_advanced_exa instead. Deep search with query expansion and synthesized answers (requires API key)', enabled: false },
 };
 
 export interface McpConfig {

--- a/src/tools/companyResearch.ts
+++ b/src/tools/companyResearch.ts
@@ -11,7 +11,7 @@ import { checkpoint } from "agnost";
 export function registerCompanyResearchTool(server: McpServer, config?: { exaApiKey?: string; userProvidedApiKey?: boolean }): void {
   server.tool(
     "company_research_exa",
-    `Research any company to get business information, news, and insights.
+    `[Deprecated: Use web_search_advanced_exa instead] Research any company to get business information, news, and insights.
 
 Best for: Learning about a company's products, services, recent news, or industry position.
 Returns: Company information from trusted business sources.`,

--- a/src/tools/deepResearchCheck.ts
+++ b/src/tools/deepResearchCheck.ts
@@ -15,7 +15,7 @@ function delay(ms: number): Promise<void> {
 export function registerDeepResearchCheckTool(server: McpServer, config?: { exaApiKey?: string; userProvidedApiKey?: boolean }): void {
   server.tool(
     "deep_researcher_check",
-    `Check status and get results from a deep research task.
+    `[Deprecated] Check status and get results from a deep research task.
 
 Best for: Getting the research report after calling deep_researcher_start.
 Returns: Research report when complete, or status update if still running.

--- a/src/tools/deepResearchStart.ts
+++ b/src/tools/deepResearchStart.ts
@@ -10,7 +10,7 @@ import { checkpoint } from "agnost";
 export function registerDeepResearchStartTool(server: McpServer, config?: { exaApiKey?: string; userProvidedApiKey?: boolean }): void {
   server.tool(
     "deep_researcher_start",
-    `Start an AI research agent that searches, reads, and writes a detailed report. Takes 15 seconds to 2 minutes.
+    `[Deprecated] Start an AI research agent that searches, reads, and writes a detailed report. Takes 15 seconds to 2 minutes.
 
 Best for: Complex research questions needing deep analysis and synthesis.
 Returns: Research ID - use deep_researcher_check to get results.

--- a/src/tools/deepSearch.ts
+++ b/src/tools/deepSearch.ts
@@ -11,7 +11,7 @@ import { checkpoint } from "agnost";
 export function registerDeepSearchTool(server: McpServer, config?: { exaApiKey?: string; userProvidedApiKey?: boolean }): void {
   server.tool(
     "deep_search_exa",
-    `Deep search with automatic query expansion for thorough research. Generates multiple search variations to find results from multiple angles, then synthesizes a short answer with citations.
+    `[Deprecated: Use web_search_advanced_exa instead] Deep search with automatic query expansion for thorough research. Generates multiple search variations to find results from multiple angles, then synthesizes a short answer with citations.
 
 Best for: Complex questions needing information from multiple angles.
 Returns: A synthesized answer with citations, plus individual search results with highlights. When structuredOutput is enabled, returns structured JSON instead of markdown.

--- a/src/tools/peopleSearch.ts
+++ b/src/tools/peopleSearch.ts
@@ -11,7 +11,7 @@ import { checkpoint } from "agnost";
 export function registerPeopleSearchTool(server: McpServer, config?: { exaApiKey?: string; userProvidedApiKey?: boolean }): void {
   server.tool(
     "people_search_exa",
-    `Find people and their professional profiles.
+    `[Deprecated: Use web_search_advanced_exa instead] Find people and their professional profiles.
 
 Best for: Finding professionals, executives, or anyone with a public profile.
 Returns: Profile information and links.`,


### PR DESCRIPTION
Mark company_research_exa, people_search_exa, deep_search_exa, deep_researcher_start, deep_researcher_check, and linkedin_search_exa as deprecated in favor of web_search_advanced_exa. 

Remove them from README. 

Retained tools: web_search_exa, web_search_advanced_exa, get_code_context_exa, crawling_exa.