### PR TITLE
Migrate to exa-js and improve webSearch and crawling tools

### DIFF
--- a/src/tools/crawling.ts
+++ b/src/tools/crawling.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import axios from "axios";
+import { Exa, ExaError } from "exa-js";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { API_CONFIG } from "./config.js";
 import { createRequestLogger } from "../utils/logger.js";
@@ -7,83 +7,121 @@ import { handleRateLimitError } from "../utils/errorHandler.js";
 import { sanitizeContentsResponse } from "../utils/exaResponseSanitizer.js";
 import { checkpoint } from "agnost";
 
+interface CrawlStatus {
+  id: string;
+  status: string;
+  error?: { tag: string; httpStatusCode?: number | null };
+}
+
+function formatCrawlResults(results: any[], errors: CrawlStatus[]): string {
+  if (results.length === 0 && errors.length === 0) return 'No content found.';
+  const lines: string[] = [];
+  for (const r of results) {
+    lines.push(`# ${r.title || '(no title)'}`);
+    lines.push(`URL: ${r.url}`);
+    if (r.publishedDate) lines.push(`Published: ${r.publishedDate.split('T')[0]}`);
+    if (r.author) lines.push(`Author: ${r.author}`);
+    lines.push('');
+    if (r.text) lines.push(r.text);
+    lines.push('');
+  }
+  for (const err of errors) {
+    lines.push(`Error fetching ${err.id}: ${err.error?.tag ?? 'unknown error'}`);
+  }
+  return lines.join('\n').trim();
+}
+
 export function registerCrawlingTool(server: McpServer, config?: { exaApiKey?: string; userProvidedApiKey?: boolean }): void {
   server.tool(
     "crawling_exa",
-    `Get the full content of a specific webpage. Use when you have an exact URL.
+    `Read a webpage's full content as clean markdown. Use after web_search_exa when highlights are insufficient or to read any URL.
 
-Best for: Extracting content from a known URL.
-Returns: Full text content and metadata from the page.`,
+Best for: Extracting full content from known URLs. Batch multiple URLs in one call.
+Returns: Clean text content and metadata from the page(s).`,
     {
-      url: z.string().describe("URL to crawl and extract content from"),
-      maxCharacters: z.coerce.number().optional().describe("Maximum characters to extract (must be a number, default: 3000)")
+      urls: z.array(z.string()).describe("URLs to read. Batch multiple URLs in one call."),
+      maxCharacters: z.coerce.number().optional().describe("Maximum characters to extract per page (must be a number, default: 3000)"),
+      maxAgeHours: z.coerce.number().optional().describe("Maximum age of cached content in hours. 0 = always livecrawl, omit = use cache with livecrawl fallback."),
+      subpages: z.coerce.number().optional().describe("Number of subpages to also crawl from each URL."),
+      subpageTarget: z.string().optional().describe("Keywords to prioritize when selecting subpages"),
     },
     {
       readOnlyHint: true,
       destructiveHint: false,
       idempotentHint: true
     },
-    async ({ url, maxCharacters }) => {
+    async ({ urls, maxCharacters, maxAgeHours, subpages, subpageTarget }) => {
       const requestId = `crawling_exa-${Date.now()}-${Math.random().toString(36).substring(2, 7)}`;
       const logger = createRequestLogger(requestId, 'crawling_exa');
-      
-      logger.start(url);
-      
+
+      logger.start(urls.join(', '));
+
       try {
-        // Create a fresh axios instance for each request
-        const axiosInstance = axios.create({
-          baseURL: API_CONFIG.BASE_URL,
-          headers: {
-            'accept': 'application/json',
-            'content-type': 'application/json',
-            'x-api-key': config?.exaApiKey || process.env.EXA_API_KEY || '',
-            'x-exa-integration': 'crawling-mcp'
-          },
-          timeout: 25000
-        });
+        const exa = new Exa(config?.exaApiKey || process.env.EXA_API_KEY || '');
 
         const crawlRequest = {
-          ids: [url],
+          ids: urls,
           contents: {
             text: {
               maxCharacters: maxCharacters || API_CONFIG.DEFAULT_MAX_CHARACTERS
             },
-            livecrawl: 'preferred'
+            ...(maxAgeHours !== undefined ? { maxAgeHours } : { livecrawl: 'preferred' }),
+            ...(subpages && { subpages }),
+            ...(subpageTarget && { subpageTarget: [subpageTarget] }),
           }
         };
-        
+
         checkpoint('crawl_request_prepared');
         logger.log("Sending crawl request to Exa API");
-        
-        const response = await axiosInstance.post(
+
+        const response = await exa.request<any>(
           '/contents',
+          'POST',
           crawlRequest,
-          { timeout: 25000 }
+          undefined,
+          { 'x-exa-integration': 'crawling-mcp' }
         );
-        
+
         checkpoint('crawl_response_received');
         logger.log("Received response from Exa API");
 
-        if (!response.data || !response.data.results || response.data.results.length === 0) {
+        const statuses: CrawlStatus[] = Array.isArray(response?.statuses) ? response.statuses : [];
+        const urlErrors = statuses.filter((s) => s.status === 'error');
+
+        if (!response || !response.results || response.results.length === 0) {
           logger.log("Warning: Empty or invalid response from Exa API");
           checkpoint('crawl_complete');
+          if (urlErrors.length > 0) {
+            const msg = urlErrors.map((e) => `${e.id}: ${e.error?.tag ?? 'unknown error'}`).join('; ');
+            return {
+              content: [{
+                type: "text" as const,
+                text: `Error fetching URL(s): ${msg}`
+              }],
+              isError: true,
+            };
+          }
           return {
             content: [{
               type: "text" as const,
-              text: "No content found for the provided URL."
+              text: "No content found for the provided URL(s)."
             }]
           };
         }
 
-        logger.log(`Successfully crawled content from URL`);
+        logger.log(`Successfully crawled content from ${response.results.length} URL(s)`);
+
+        const sanitized = sanitizeContentsResponse(response);
+        const results = Array.isArray(sanitized.results) ? sanitized.results : [];
+        const formattedText = formatCrawlResults(results, urlErrors);
 
         const result = {
           content: [{
             type: "text" as const,
-            text: JSON.stringify(sanitizeContentsResponse(response.data), null, 2)
+            text: formattedText
           }]
         };
-        
+
         checkpoint('crawl_complete');
         logger.complete();
         return result;
@@ -96,12 +134,11 @@ Returns: Full text content and metadata from the page.`,
           return rateLimitResult;
         }
         
-        if (axios.isAxiosError(error)) {
-          // Handle Axios errors specifically
-          const statusCode = error.response?.status || 'unknown';
-          const errorMessage = error.response?.data?.message || error.message;
-          
-          logger.log(`Axios error (${statusCode}): ${errorMessage}`);
+        if (error instanceof ExaError) {
+          const statusCode = error.statusCode || 'unknown';
+          const errorMessage = error.message;
+
+          logger.log(`Exa error (${statusCode}): ${errorMessage}`);
           return {
             content: [{
               type: "text" as const,

--- a/src/tools/webSearch.ts
+++ b/src/tools/webSearch.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import axios from "axios";
+import { Exa, ExaError } from "exa-js";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { API_CONFIG } from "./config.js";
 import { ExaSearchRequest, ExaSearchResponse } from "../types.js";
@@ -8,68 +8,87 @@ import { handleRateLimitError } from "../utils/errorHandler.js";
 import { sanitizeSearchResponse } from "../utils/exaResponseSanitizer.js";
 import { checkpoint } from "agnost"
 
+function resolveFreshness(freshness?: string, category?: string): { startPublishedDate?: string; maxAgeHours?: number } {
+  if (!freshness || freshness === 'any') return {};
+  if (category === 'company' || category === 'people') return {};
+  const offsets: Record<string, number> = {
+    '24h': 864e5,
+    'week': 6048e5,
+    'month': 2592e6,
+    'year': 31536e6,
+  };
+  const offset = offsets[freshness];
+  if (!offset) return {};
+  const startPublishedDate = new Date(Date.now() - offset).toISOString().split('T')[0];
+  const maxAgeHours = freshness === '24h' || freshness === 'week' ? 0 : undefined;
+  return { startPublishedDate, maxAgeHours };
+}
+
 export function registerWebSearchTool(server: McpServer, config?: { exaApiKey?: string; userProvidedApiKey?: boolean }): void {
   server.tool(
     "web_search_exa",
     `Search the web for any topic and get clean, ready-to-use content.
 
 Best for: Finding current information, news, facts, or answering questions about any topic.
-Returns: Clean text content from top search results, ready for LLM use.`,
+Returns: Clean text content from top search results, ready for LLM use.
+
+Query tips: describe the ideal page, not keywords. "blog post comparing React and Vue performance" not "React vs Vue".
+If highlights are insufficient, follow up with crawling_exa on the best URLs.`,
     {
-      query: z.string().describe("Websearch query"),
-      numResults: z.coerce.number().optional().describe("Number of search results to return (must be a number, default: 8)"),
+      query: z.string().describe("Natural language search query. Should be a semantically rich description of the ideal page, not just keywords."),
+      numResults: z.coerce.number().min(1).max(100).optional().describe("Number of search results to return (must be a number, default: 8)"),
       livecrawl: z.enum(['fallback', 'preferred']).optional().describe("Live crawl mode - 'fallback': use live crawling as backup if cached content unavailable, 'preferred': prioritize live crawling (default: 'fallback')"),
       type: z.enum(['auto', 'fast']).optional().describe("Search type - 'auto': balanced search (default), 'fast': quick results"),
-      category: z.enum(['company', 'research paper', 'people']).optional().describe("Filter results to a specific category - 'company': company websites and profiles, 'research paper': academic papers and research, 'people': LinkedIn profiles and personal bios"),
+      category: z.enum(['company', 'research paper', 'news', 'tweet', 'personal site', 'people', 'financial report']).optional().describe("Filter results to a specific category"),
+      freshness: z.enum(['24h', 'week', 'month', 'year', 'any']).optional().describe("How recent results should be. Only set when recency matters."),
+      includeDomains: z.array(z.string()).optional().describe("List of domains to include in the search. If specified, results will only come from these domains."),
     },
     {
       readOnlyHint: true,
       destructiveHint: false,
       idempotentHint: true
     },
-    async ({ query, numResults, livecrawl, type, category }) => {
+    async ({ query, numResults, livecrawl, type, category, freshness, includeDomains }) => {
       const requestId = `web_search_exa-${Date.now()}-${Math.random().toString(36).substring(2, 7)}`;
       const logger = createRequestLogger(requestId, 'web_search_exa');
-      
+
       logger.start(query);
-      
+
       try {
-        // Create a fresh axios instance for each request
-        const axiosInstance = axios.create({
-          baseURL: API_CONFIG.BASE_URL,
-          headers: {
-            'accept': 'application/json',
-            'content-type': 'application/json',
-            'x-api-key': config?.exaApiKey || process.env.EXA_API_KEY || '',
-            'x-exa-integration': 'web-search-mcp'
-          },
-          timeout: 25000
-        });
+        const exa = new Exa(config?.exaApiKey || process.env.EXA_API_KEY || '');
+
+        const { startPublishedDate, maxAgeHours } = resolveFreshness(freshness, category);
 
         const searchRequest: ExaSearchRequest = {
           query,
           type: type || "auto",
           numResults: numResults || API_CONFIG.DEFAULT_NUM_RESULTS,
           ...(category && { category }),
+          ...(includeDomains?.length && { includeDomains }),
+          ...(startPublishedDate && { startPublishedDate }),
           contents: {
-            highlights: true,
-            livecrawl: livecrawl || 'fallback'
+            highlights: { query },
+            text: { maxCharacters: 300 },
+            livecrawl: livecrawl || 'fallback',
+            ...(maxAgeHours !== undefined && { maxAgeHours } as any),
           }
         };
-        
+
         checkpoint('web_search_request_prepared');
         logger.log("Sending request to Exa API");
-        
-        const response = await axiosInstance.post<ExaSearchResponse>(
+
+        const response = await exa.request<ExaSearchResponse>(
           API_CONFIG.ENDPOINTS.SEARCH,
+          'POST',
           searchRequest,
-          { timeout: 25000 }
+          undefined,
+          { 'x-exa-integration': 'web-search-mcp' }
         );
-        
+
         checkpoint('exa_search_response_received');
         logger.log("Received response from Exa API");
 
-        if (!response.data || !response.data.results || response.data.results.length === 0) {
+        if (!response || !response.results || response.results.length === 0) {
           logger.log("Warning: Empty or invalid response from Exa API");
           checkpoint('web_search_complete');
           return {
@@ -80,20 +99,23 @@ Returns: Clean text content from top search results, ready for LLM use.`,
           };
         }
 
-        logger.log(`Received ${response.data.results.length} results with highlights`);
+        logger.log(`Received ${response.results.length} results with highlights`);
 
-        const sanitized = sanitizeSearchResponse(response.data);
+        const sanitized = sanitizeSearchResponse(response);
         const results = Array.isArray(sanitized.results) ? sanitized.results : [];
 
         const formattedResults = results.map((r) => {
-          const highlights = Array.isArray(r.highlights) ? r.highlights.join('\n') : '';
           const lines = [
             `Title: ${r.title || 'N/A'}`,
             `URL: ${r.url}`,
             `Published: ${r.publishedDate || 'N/A'}`,
             `Author: ${r.author || 'N/A'}`,
-            `Highlights:\n${highlights}`,
           ];
+          if (Array.isArray(r.highlights) && r.highlights.length > 0) {
+            lines.push(`Highlights:\n${r.highlights.join('\n')}`);
+          } else if (r.text) {
+            lines.push(`Text: ${r.text}`);
+          }
           return lines.join('\n');
         }).join('\n\n---\n\n');
 
@@ -119,12 +141,11 @@ Returns: Clean text content from top search results, ready for LLM use.`,
           return rateLimitResult;
         }
         
-        if (axios.isAxiosError(error)) {
-          // Handle Axios errors specifically
-          const statusCode = error.response?.status || 'unknown';
-          const errorMessage = error.response?.data?.message || error.message;
-          
-          logger.log(`Axios error (${statusCode}): ${errorMessage}`);
+        if (error instanceof ExaError) {
+          const statusCode = error.statusCode || 'unknown';
+          const errorMessage = error.message;
+
+          logger.log(`Exa error (${statusCode}): ${errorMessage}`);
           return {
             content: [{
               type: "text" as const,


### PR DESCRIPTION
## Summary
- **webSearch**: Added `freshness` filter, `includeDomains`, expanded `category` options (news, tweet, personal site, financial report), query-aware highlights, text fallback when highlights are empty, better query prompting in tool description, and `numResults` min/max validation
- **crawling**: Added batch URL support (`url` → `urls` array), `maxAgeHours` for cache control, `subpages`/`subpageTarget` for subpage crawling, per-URL error reporting via response statuses, and clean markdown output replacing raw JSON
- Both tools migrated from axios to exa-js SDK (`Exa` client + `ExaError`)
