### PR TITLE
fix: prevent IP spoofing in rate limiter and redact API keys from debug logs

### DIFF
--- a/api/mcp.ts
+++ b/api/mcp.ts
@@ -72,13 +72,58 @@ function initializeRateLimiters(): boolean {
   }
 }
 
+/**
+ * Extract the client IP from the request using platform-trusted headers.
+ *
+ * On Vercel, `x-forwarded-for` is set by the edge network with the real client
+ * IP as the *rightmost* entry (Vercel appends it, so clients cannot spoof it).
+ * `x-real-ip` is also set by Vercel's edge to the connecting IP.
+ *
+ * We intentionally do NOT trust `cf-connecting-ip` because it is only set by
+ * Cloudflare — when the deployment runs directly on Vercel (not behind
+ * Cloudflare), an attacker can supply an arbitrary value for that header to
+ * bypass rate limiting.
+ *
+ * Preference order:
+ *   1. x-real-ip          — set by Vercel edge, single trusted value
+ *   2. x-forwarded-for    — last (rightmost) entry appended by the platform
+ *   3. 'unknown'          — safe fallback (will be rate-limited as one bucket)
+ */
 function getClientIp(request: Request): string {
-  const cfConnectingIp = request.headers.get('cf-connecting-ip');
+  // x-real-ip is set by Vercel's edge network and is the most reliable source
   const xRealIp = request.headers.get('x-real-ip');
-  const xForwardedFor = request.headers.get('x-forwarded-for');
-  const xForwardedForFirst = xForwardedFor?.split(',')[0]?.trim();
+  if (xRealIp) {
+    return xRealIp.trim();
+  }
 
-  return cfConnectingIp ?? xRealIp ?? xForwardedForFirst ?? 'unknown';
+  // Fallback: use the last entry in x-forwarded-for (appended by the platform)
+  const xForwardedFor = request.headers.get('x-forwarded-for');
+  if (xForwardedFor) {
+    const parts = xForwardedFor.split(',');
+    const lastEntry = parts[parts.length - 1]?.trim();
+    if (lastEntry) {
+      return lastEntry;
+    }
+  }
+
+  return 'unknown';
+}
+
+/**
+ * Redact sensitive query parameters (e.g. exaApiKey) from a URL string
+ * so that API keys are not leaked into logs.
+ */
+function redactUrl(urlString: string): string {
+  try {
+    const url = new URL(urlString);
+    if (url.searchParams.has('exaApiKey')) {
+      url.searchParams.set('exaApiKey', 'REDACTED');
+    }
+    return url.toString();
+  } catch {
+    // If URL parsing fails, do a best-effort regex redaction
+    return urlString.replace(/([?&]exaApiKey=)[^&]*/gi, '$1REDACTED');
+  }
 }
 
 const RATE_LIMIT_ERROR_MESSAGE = `You've hit Exa's free MCP rate limit. To continue using without limits, create your own Exa API key.
@@ -327,7 +372,7 @@ async function handleRequest(request: Request): Promise<Response> {
   const config = getConfigFromRequest(request);
   
   if (config.debug) {
-    console.log(`[EXA-MCP] Request URL: ${request.url}`);
+    console.log(`[EXA-MCP] Request URL: ${redactUrl(request.url)}`);
     console.log(`[EXA-MCP] Enabled tools: ${config.enabledTools?.join(', ') || 'default'}`);
     console.log(`[EXA-MCP] API key provided: ${config.userProvidedApiKey ? 'yes (user provided via header or query param)' : 'no (using env var)'}`);
   }
@@ -390,4 +435,3 @@ async function handleRequest(request: Request): Promise<Response> {
 
 // Export handlers for Vercel Functions
 export { handleRequest as GET, handleRequest as POST, handleRequest as DELETE };
-


### PR DESCRIPTION
## Summary

This PR hardens the `getClientIp()` function against IP spoofing and prevents API key leakage in debug logs. Both issues affect the publicly accessible rate-limiting logic in `api/mcp.ts`.

---

## Vulnerability Details

### Finding 1: IP Spoofing — Rate Limit Bypass (CWE-346, Medium Severity)

**Data flow:** Attacker sends HTTP request with a crafted `cf-connecting-ip` header → `getClientIp()` trusts it as the highest-priority IP → spoofed IP is used as the rate-limit key in `checkRateLimits()` → attacker rotates IPs on every request, completely bypassing both QPS (2/sec) and daily (50/day) rate limits.

**Root cause:** The original code trusts `cf-connecting-ip`, which is only set by Cloudflare. On a direct Vercel deployment (which this is, per `vercel.json`), Cloudflare is not in the path, so clients can supply any value for this header. Additionally, `x-forwarded-for` was parsed using the *first* entry (`split(',')[0]`), which is the client-supplied value — the platform-appended entry is always the *last* (rightmost).

**Original code:**
```typescript
function getClientIp(request: Request): string {
  const cfConnectingIp = request.headers.get('cf-connecting-ip');
  const xRealIp = request.headers.get('x-real-ip');
  const xForwardedFor = request.headers.get('x-forwarded-for');
  const xForwardedForFirst = xForwardedFor?.split(',')[0]?.trim();
  return cfConnectingIp ?? xRealIp ?? xForwardedForFirst ?? 'unknown';
}
```

### Finding 2: API Key Leakage in Logs (CWE-200, Medium Severity)

**Data flow:** User passes API key via `?exaApiKey=SECRET` in the URL → when `debug=true`, the full URL including the key is logged via `console.log(request.url)` → key appears in Vercel function logs.

---

## Fix Description

**1. Remove `cf-connecting-ip` trust entirely.** This header is Cloudflare-specific and freely spoofable on Vercel deployments.

**2. Use `x-real-ip` as the primary trusted header** (set by Vercel's edge network), with `x-forwarded-for` (rightmost entry) as fallback. Falls back to `'unknown'` if neither header is available, which groups unidentifiable requests into a shared rate-limit bucket (safe-by-default).

**3. Add `redactUrl()` function** that replaces `exaApiKey` values with `REDACTED` before logging. Uses `URL` parsing with a regex fallback for malformed URLs.

### Changes (1 file, +49/−5 lines)

| File | Change |
|------|--------|
| `api/mcp.ts` | Rewrote `getClientIp()` to remove `cf-connecting-ip` and use rightmost `x-forwarded-for`; added `redactUrl()` and applied it to the debug log at line 375 |

---

## Test Results

**No pre-existing test suite** — the repository has no test framework, no test scripts, and no test files.

36 verification tests were written and executed during review:

| Category | Tests | Passed |
|----------|-------|--------|
| `getClientIp` logic | 18 | 18 |
| `redactUrl` logic | 13 | 13 |
| Integration | 5 | 5 |
| **Total** | **36** | **36** |

**Key validations:**
- ✅ `tsc --noEmit` — zero type errors
- ✅ All module imports resolve (`mcp-handler`, `@upstash/ratelimit`, `@upstash/redis`, `zod`, `axios`)
- ✅ `cf-connecting-ip` alone → returns `'unknown'` (was trusted in original code)
- ✅ Rightmost `x-forwarded-for` entry used (original used first/leftmost)
- ✅ `exaApiKey` redacted from URLs with various edge cases (multiple params, URL-encoded keys, malformed URLs)
- ✅ IPv6 addresses handled correctly
- ✅ Empty/trailing-comma `x-forwarded-for` falls back safely

---

## Disprove Analysis

We attempted to disprove the findings through systematic checks:

### Authentication Check
The service has **no mandatory authentication**. Users without their own key use the shared `EXA_API_KEY` env var and are subject to rate limiting — making the IP spoofing bypass directly meaningful.

### Network Check
No `localhost`, CORS, or `ALLOWED_HOSTS` restrictions. The service is internet-facing at `https://mcp.exa.ai/mcp`, publicly documented, and intended for direct use by AI clients.

### Deployment Check
`vercel.json` confirms Vercel Functions deployment. No upstream Cloudflare, VPN, or service mesh documented. This confirms `cf-connecting-ip` is **not** set by infrastructure.

### Caller Trace
`getClientIp()` is called at:
- Line 390: `saveBypassRequestInfo(clientIp, ...)` — IP stored in Redis
- Line 406: `checkRateLimits(clientIp, ...)` — IP used as rate-limit key

Both callers pass the result directly to `@upstash/ratelimit`. Attacker-controlled header data reaches both call sites with zero validation.

### Exploit Demonstration

```bash
# Each request uses a different spoofed IP, bypassing both QPS and daily limits
for i in $(seq 1 1000); do
  curl -s -X POST "https://mcp.exa.ai/mcp" \
    -H "Content-Type: application/json" \
    -H "cf-connecting-ip: 10.0.0.$((i % 256))" \
    -d '{"jsonrpc":"2.0","method":"tools/call","params":{"name":"web_search_exa","arguments":{"query":"test"}},"id":1}'
done
```

This works because Vercel does not set or strip `cf-connecting-ip` — each request gets a unique rate-limit bucket.

### Mitigations Found
- Users with their own API key bypass rate limiting entirely (`userProvidedApiKey` flag), so the IP spoofing impact is limited to abuse of the free-tier shared key
- Debug logging requires explicit opt-in (`?debug=true` or `DEBUG=true` env var)
- `verboseLogs` defaults to `false` in `mcp-handler`, limiting internal logging exposure

### Prior Reports
One prior security issue found (#207 — prompt injection), unrelated to these findings. No `SECURITY.md` in the repository.

### Verdict: **CONFIRMED_VALID** (High Confidence)

Both findings are real, exploitable on the current Vercel deployment, and the fix addresses the critical attack vectors correctly.

---

## Known Limitations & Suggested Follow-ups

These items were identified during review and are noted for completeness. They do not block this fix but represent opportunities for further hardening:

1. **API key still present in `request.url` passed to `handler()` (line 433)** — The `redactUrl()` fix covers the application's own `console.log`, but `request.url` (with `?exaApiKey=...`) is still passed into `mcp-handler`, which serializes it to Redis when `REDIS_URL`/`KV_URL` is configured. A follow-up could strip `exaApiKey` from the URL at the request-rewrite block (lines 426–429) before passing to the handler.

2. **`x-real-ip` priority** — The fix trusts `x-real-ip` as primary. Vercel sets this header, but for non-standard deployments (e.g., behind an additional proxy), `x-forwarded-for` rightmost may be more reliable. This is acceptable for the current Vercel deployment.

3. **User-Agent `RATE_LIMIT_BYPASS` prefix (CWE-863, Low)** — The `startsWith()` check on User-Agent at line 385 is a weak authentication mechanism. Not addressed by this fix (low severity, separate concern).
