### PR TITLE
Deprecating /context and migrating to /search endpoint.

### DIFF
--- a/src/tools/exaCode.ts
+++ b/src/tools/exaCode.ts
@@ -2,57 +2,68 @@ import { z } from "zod";
 import { Exa } from "exa-js";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { API_CONFIG } from "./config.js";
-import { ExaCodeRequest, ExaCodeResponse } from "../types.js";
+import { ExaSearchRequest, ExaSearchResponse } from "../types.js";
 import { createRequestLogger } from "../utils/logger.js";
 import { retryWithBackoff, formatToolError } from "../utils/errorHandler.js";
+import { sanitizeSearchResponse } from "../utils/exaResponseSanitizer.js";
 import { checkpoint } from "agnost";
 
 export function registerExaCodeTool(server: McpServer, config?: { exaApiKey?: string; userProvidedApiKey?: boolean }): void {
   server.tool(
     "get_code_context_exa",
-    `Find code examples, documentation, and programming solutions. Searches GitHub, Stack Overflow, and official docs.
+    `Find code examples, documentation, and programming solutions. 
 
 Best for: Any programming question - API usage, library examples, code snippets, debugging help.
-Returns: Relevant code and documentation, formatted for easy reading.`,
+Returns: Relevant code and documentation.
+
+Query tips: describe what you're looking for specifically. "Python requests library POST with JSON body" not "python http".
+If highlights are insufficient, follow up with crawling_exa on the best URLs.`,
     {
       query: z.string().describe("Search query to find relevant context for APIs, Libraries, and SDKs. For example, 'React useState hook examples', 'Python pandas dataframe filtering', 'Express.js middleware', 'Next js partial prerendering configuration'"),
-      tokensNum: z.coerce.number().min(1000).max(50000).default(5000).describe("Number of tokens to return (must be a number, 1000-50000). Default is 5000 tokens. Adjust this value based on how much context you need - use lower values for focused queries and higher values for comprehensive documentation.")
+      numResults: z.coerce.number().min(1).max(20).optional().describe("Number of search results to return (must be a number, default: 8)"),
     },
     {
       readOnlyHint: true,
       destructiveHint: false,
       idempotentHint: true
     },
-    async ({ query, tokensNum }) => {
+    async ({ query, numResults }) => {
       const requestId = `get_code_context_exa-${Date.now()}-${Math.random().toString(36).substring(2, 7)}`;
       const logger = createRequestLogger(requestId, 'get_code_context_exa');
-      
+
       logger.start(`Searching for code context: ${query}`);
-      
+
       try {
         const exa = new Exa(config?.exaApiKey || process.env.EXA_API_KEY || '');
 
-        const exaCodeRequest: ExaCodeRequest = {
+        const searchRequest: ExaSearchRequest = {
           query,
-          tokensNum
+          type: "fast",
+          numResults: numResults || API_CONFIG.DEFAULT_NUM_RESULTS,
+          contents: {
+            highlights: {
+              query,
+            },
+            text: { maxCharacters: 300 },
+          }
         };
-        
+
         checkpoint('code_context_request_prepared');
-        logger.log("Sending code context request to Exa API");
-        
-        const response = await retryWithBackoff(() => exa.request<ExaCodeResponse>(
-          API_CONFIG.ENDPOINTS.CONTEXT,
+        logger.log("Sending code search request to Exa API");
+
+        const response = await retryWithBackoff(() => exa.request<ExaSearchResponse>(
+          API_CONFIG.ENDPOINTS.SEARCH,
           'POST',
-          exaCodeRequest,
+          searchRequest,
           undefined,
           { 'x-exa-integration': 'exa-code-mcp' }
         ));
 
         checkpoint('code_context_response_received');
-        logger.log("Received code context response from Exa API");
+        logger.log("Received code search response from Exa API");
 
-        if (!response) {
-          logger.log("Warning: Empty response from Exa Code API");
+        if (!response || !response.results || response.results.length === 0) {
+          logger.log("Warning: Empty or invalid response from Exa API");
           checkpoint('code_context_complete');
           return {
             content: [{
@@ -62,25 +73,36 @@ Returns: Relevant code and documentation, formatted for easy reading.`,
           };
         }
 
-        logger.log(`Code search completed with ${response.resultsCount || 0} results`);
+        logger.log(`Received ${response.results.length} results with highlights`);
 
-        // Return the actual code content from the response field
-        const codeContent = typeof response.response === 'string'
-          ? response.response
-          : JSON.stringify(response.response, null, 2);
+        const sanitized = sanitizeSearchResponse(response);
+        const results = Array.isArray(sanitized.results) ? sanitized.results : [];
 
-        const searchTime = typeof response.searchTime === 'number' ? response.searchTime : undefined;
+        const formattedResults = results.map((r) => {
+          const lines = [
+            `Title: ${r.title || 'N/A'}`,
+            `URL: ${r.url}`,
+          ];
+          if (Array.isArray(r.highlights) && r.highlights.length > 0) {
+            lines.push(`Code/Highlights:\n${r.highlights.join('\n')}`);
+          } else if (r.text) {
+            lines.push(`Text: ${r.text}`);
+          }
+          return lines.join('\n');
+        }).join('\n\n---\n\n');
+
+        const searchTime = typeof sanitized.searchTime === 'number' ? sanitized.searchTime : undefined;
 
         const result = {
           content: [{
             type: "text" as const,
-            text: codeContent,
+            text: formattedResults,
             _meta: {
               searchTime: searchTime
             }
           }]
         };
-        
+
         checkpoint('code_context_complete');
         logger.complete();
         return result;


### PR DESCRIPTION
Migrated exaCode tool to use /search instead of /context. 