### PR TITLE
fix: prevent IP-based rate limit bypass via spoofed headers (CWE-346)

### DIFF
--- a/api/mcp.ts
+++ b/api/mcp.ts
@@ -72,13 +72,41 @@ function initializeRateLimiters(): boolean {
   }
 }
 
+/**
+ * Extract the client IP from the request using platform-trusted headers.
+ *
+ * On Vercel, `x-real-ip` is set by the edge network to the connecting client's
+ * IP and cannot be spoofed by the client. `x-forwarded-for` is also set by
+ * Vercel's edge, with the real client IP appended as the *rightmost* entry.
+ *
+ * We intentionally do NOT trust `cf-connecting-ip` because it is only set by
+ * Cloudflare — when the deployment runs directly on Vercel (not behind
+ * Cloudflare), an attacker can supply an arbitrary value for that header to
+ * bypass rate limiting.
+ *
+ * Preference order:
+ *   1. x-real-ip          — set by Vercel edge, single trusted value
+ *   2. x-forwarded-for    — last (rightmost) entry appended by the platform
+ *   3. 'unknown'          — safe fallback (will be rate-limited as one bucket)
+ */
 function getClientIp(request: Request): string {
-  const cfConnectingIp = request.headers.get('cf-connecting-ip');
+  // x-real-ip is set by Vercel's edge network and is the most reliable source
   const xRealIp = request.headers.get('x-real-ip');
-  const xForwardedFor = request.headers.get('x-forwarded-for');
-  const xForwardedForFirst = xForwardedFor?.split(',')[0]?.trim();
+  if (xRealIp) {
+    return xRealIp.trim();
+  }
 
-  return cfConnectingIp ?? xRealIp ?? xForwardedForFirst ?? 'unknown';
+  // Fallback: use the last entry in x-forwarded-for (appended by the platform)
+  const xForwardedFor = request.headers.get('x-forwarded-for');
+  if (xForwardedFor) {
+    const parts = xForwardedFor.split(',');
+    const lastEntry = parts[parts.length - 1]?.trim();
+    if (lastEntry) {
+      return lastEntry;
+    }
+  }
+
+  return 'unknown';
 }
 
 const RATE_LIMIT_ERROR_MESSAGE = `You've hit Exa's free MCP rate limit. To continue using without limits, create your own Exa API key.
@@ -390,4 +418,3 @@ async function handleRequest(request: Request): Promise<Response> {
 
 // Export handlers for Vercel Functions
 export { handleRequest as GET, handleRequest as POST, handleRequest as DELETE };
-


### PR DESCRIPTION
## Vulnerability Summary

**CWE-346: Origin Validation Error** — IP-based rate limit bypass via spoofable HTTP headers  
**Severity:** High  
**File:** `api/mcp.ts` — `getClientIp()` function  
**Deployment:** Public internet endpoint at `https://mcp.exa.ai/mcp` (Vercel Functions)

### Data Flow

1. An unauthenticated HTTP request arrives at the Vercel Function handler (`handleRequest`)
2. `getClientIp(request)` extracts the client IP from request headers
3. The returned IP is passed to `checkRateLimits()` to enforce per-IP daily (50 req) and QPS (2 req/s) limits
4. **Old code** used this priority: `cf-connecting-ip ?? x-real-ip ?? x-forwarded-for[0] ?? "unknown"`

### The Problem

On Vercel's platform:

| Header | Set by Vercel? | Client-controllable? |
|---|---|---|
| `x-real-ip` | ✅ Yes — overwritten by edge | ❌ No |
| `x-forwarded-for` (last entry) | ✅ Yes — appended by edge | ❌ No |
| `x-forwarded-for` (first entry) | ❌ No — prepended by client | ✅ Yes |
| `cf-connecting-ip` | ❌ No — only set by Cloudflare | ✅ Yes |

The old code checked `cf-connecting-ip` **first**. Since Vercel does not strip this header, any client can send an arbitrary value, causing the trusted `x-real-ip` to never be consulted. Each request with a different spoofed header value gets its own rate limit bucket, completely bypassing both the daily limit and QPS limit.

The old code also used `x-forwarded-for[0]` (the first/leftmost entry), which is attacker-controlled since clients can prepend arbitrary values. The platform-appended real IP is always the **last** entry.

---

## Fix Description

**Single commit, single file, 1 function changed.**

The fix rewrites `getClientIp()` to use only Vercel-trusted headers in the correct priority:

1. **`x-real-ip`** (preferred) — set and overwritten by Vercel edge, cannot be spoofed
2. **`x-forwarded-for` last entry** (fallback) — the rightmost entry is appended by the platform
3. **`"unknown"`** (safe default) — groups unidentifiable clients into one shared bucket

**Removed:** Trust in `cf-connecting-ip` (not a Vercel header, freely spoofable).  
**Changed:** `x-forwarded-for` parsing from `split(",")[0]` (first/client-controlled) to `split(",")[parts.length - 1]` (last/platform-appended).

### Rationale

- Vercel's `@vercel/next` source confirms `x-real-ip` is the canonical IP header (`n.Ip = "x-real-ip"`)
- This aligns with Vercel's own documentation on trusted headers
- The fix is minimal (1 file, 1 function) and preserves all existing rate limiting logic

---

## Test Results

### Unit-level verification

- ✅ With only `x-real-ip` set → returns `x-real-ip` value
- ✅ With both `cf-connecting-ip` and `x-real-ip` set → returns `x-real-ip` (old code returned spoofed `cf-connecting-ip`)
- ✅ With only `x-forwarded-for: fake, real` → returns `real` (last entry; old code returned `fake`)
- ✅ With no headers → returns `"unknown"`
- ✅ Whitespace in header values is trimmed

### Regression check

- ✅ No other callers of `getClientIp()` exist outside `api/mcp.ts`
- ✅ The function signature and return type are unchanged
- ✅ All downstream consumers (`checkRateLimits`, `saveBypassRequestInfo`) receive the same `string` type

---

## Disprove Analysis

We systematically attempted to disprove this finding across 8 dimensions:

### Authentication check
The service has **no authentication for free-tier users**. Authentication (Bearer token / API key) is only required for bypassing rate limits. Rate-limited free-tier access is completely unauthenticated. **No mitigation.**

### Network check
No localhost binding, no CORS restrictions, no ALLOWED_HOSTS. The service is deployed at a public internet endpoint. **No mitigation.**

### Deployment check
- `vercel.json` confirms deployment as a **Vercel Function** (public cloud, internet-facing)
- A `Dockerfile` exists but uses a different entry point (`.smithery/index.cjs`) — the vulnerable `api/mcp.ts` is Vercel-specific
- No reverse proxy, VPN, or service mesh in front. **No mitigation.**

### Caller trace
`getClientIp(request)` is called at exactly 2 locations in `api/mcp.ts`:
1. Line 373: `saveBypassRequestInfo` for bypass users (logging)
2. Line 389: `checkRateLimits` for free-tier users (rate limit enforcement)

The `request` object comes directly from Vercel's HTTP handler — headers are attacker-controlled (except headers Vercel overwrites like `x-real-ip`).

### Input validation check
No `sanitize`, `validate`, `escape`, `clean`, `whitelist`, or `allowlist` functions exist in `api/mcp.ts`. **No input validation before the vulnerable call.**

### Prior reports
No prior security issues or CVEs found in the repository's issue tracker.

### Security policy
No `SECURITY.md` exists in the repository.

### Recent commits
Only 2 commits touch `api/mcp.ts`: the merge commit introducing the file and this fix.

### Exploit sketch (against old code)

```bash
# Each request gets a unique rate limit bucket — daily and QPS limits fully bypassed
for i in $(seq 1 1000); do
  curl -X POST https://mcp.exa.ai/mcp \
    -H "Content-Type: application/json" \
    -H "cf-connecting-ip: 10.0.0.$((RANDOM % 256))" \
    -d '{"jsonrpc":"2.0","method":"tools/call","params":{"name":"web_search_exa","arguments":{"query":"test"}},"id":1}'
done
```

### Verdict: **CONFIRMED_VALID** (high confidence)

The vulnerability is trivially exploitable with a single curl command against a public, unauthenticated endpoint. No mitigating controls were found. The fix correctly addresses both attack vectors with minimal code change.

---

*Submitted as a helpful security report. Happy to discuss or adjust the approach if the team has a different header trust model in mind.*