### PR TITLE
docs: add JetBrains AI Assistant setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,6 +220,24 @@ Add to your Roo Code MCP config:
 </details>
 
 <details>
+<summary><b>JetBrains AI Assistant</b></summary>
+
+Go to **Settings** > **Tools** > **AI Assistant** > **Model Context Protocol (MCP)** and add:
+
+```json
+{
+  "mcpServers": {
+    "exa": {
+      "url": "https://mcp.exa.ai/mcp"
+    }
+  }
+}
+```
+
+Works with IntelliJ IDEA, PyCharm, WebStorm, and all JetBrains IDEs.
+</details>
+
+<details>
 <summary><b>Other Clients</b></summary>
 
 For clients that support remote MCP:


### PR DESCRIPTION
## Summary

Adds JetBrains AI Assistant setup instructions to the README's Installation section, placed between "Roo Code" and "Other Clients". This covers all JetBrains IDEs (IntelliJ IDEA, PyCharm, WebStorm, etc.) which support MCP via Streamable HTTP since the AI Assistant plugin added MCP support.

## Review & Testing Checklist for Human

- [ ] **Verify the JSON config format matches what JetBrains AI Assistant actually accepts.** The `{"mcpServers": {"exa": {"url": "..."}}}` shape is standard MCP config, but confirm it works when pasted into Settings > Tools > AI Assistant > MCP in a JetBrains IDE. Some JetBrains versions may expect a slightly different schema.
- [ ] **Confirm placement is correct** — currently between Roo Code and Other Clients. If there's an intended ordering convention (alphabetical, popularity, etc.), verify this fits.

### Notes
- JetBrains AI Assistant requires a paid JetBrains AI subscription — this is not called out in the snippet but none of the other IDE sections call out pricing either, so this is consistent.
- The `url` field points to the hosted endpoint (`https://mcp.exa.ai/mcp`), matching the pattern used by all other remote-capable client sections.

Link to Devin session: https://app.devin.ai/sessions/868816f876c64a8e83f68c62c754a1b5
Requested by: @10ishq
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/exa-labs/exa-mcp-server/pull/267" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
