### PR TITLE
docs: add Replit setup instructions and install badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 [![Install in Cursor](https://img.shields.io/badge/Install_in-Cursor-000000?style=flat-square&logoColor=white)](https://cursor.com/en/install-mcp?name=exa&config=eyJuYW1lIjoiZXhhIiwidHlwZSI6Imh0dHAiLCJ1cmwiOiJodHRwczovL21jcC5leGEuYWkvbWNwIn0=)
 [![Install in VS Code](https://img.shields.io/badge/Install_in-VS_Code-0098FF?style=flat-square&logo=visualstudiocode&logoColor=white)](https://vscode.dev/redirect/mcp/install?name=exa&config=%7B%22type%22%3A%22http%22%2C%22url%22%3A%22https%3A%2F%2Fmcp.exa.ai%2Fmcp%22%7D)
-[![Install in Replit](https://replit.com/badge?caption=Install%20in%20Replit)](https://replit.com/integrations?mcp=eyJkaXNwbGF5TmFtZSI6IkV4YSIsImJhc2VVcmwiOiJodHRwczovL21jcC5leGEuYWkvbWNwIn0=)
 [![npm version](https://badge.fury.io/js/exa-mcp-server.svg)](https://www.npmjs.com/package/exa-mcp-server)
 
 Connect AI assistants to Exa's search capabilities: web search, code search, and company research.

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![Install in Cursor](https://img.shields.io/badge/Install_in-Cursor-000000?style=flat-square&logoColor=white)](https://cursor.com/en/install-mcp?name=exa&config=eyJuYW1lIjoiZXhhIiwidHlwZSI6Imh0dHAiLCJ1cmwiOiJodHRwczovL21jcC5leGEuYWkvbWNwIn0=)
 [![Install in VS Code](https://img.shields.io/badge/Install_in-VS_Code-0098FF?style=flat-square&logo=visualstudiocode&logoColor=white)](https://vscode.dev/redirect/mcp/install?name=exa&config=%7B%22type%22%3A%22http%22%2C%22url%22%3A%22https%3A%2F%2Fmcp.exa.ai%2Fmcp%22%7D)
+[![Install in Replit](https://replit.com/badge?caption=Install%20in%20Replit)](https://replit.com/integrations?mcp=eyJkaXNwbGF5TmFtZSI6IkV4YSIsImJhc2VVcmwiOiJodHRwczovL21jcC5leGEuYWkvbWNwIn0=)
 [![npm version](https://badge.fury.io/js/exa-mcp-server.svg)](https://www.npmjs.com/package/exa-mcp-server)
 
 Connect AI assistants to Exa's search capabilities: web search, code search, and company research.
@@ -247,6 +248,17 @@ Or add manually: open LM Studio, go to the Program tab, click **Install > Edit m
 ```
 
 Exa's tools will appear in the chat. Ask your model to search the web, fetch a page, or research a topic.
+</details>
+
+<details>
+<summary><b>Replit</b></summary>
+
+Go to [**Integrations**](https://replit.com/integrations) > **MCP Servers** > **Add MCP Server**, then enter:
+
+- **Name:** `Exa`
+- **URL:** `https://mcp.exa.ai/mcp`
+
+Or [click here to install automatically](https://replit.com/integrations?mcp=eyJkaXNwbGF5TmFtZSI6IkV4YSIsImJhc2VVcmwiOiJodHRwczovL21jcC5leGEuYWkvbWNwIn0=).
 </details>
 
 <details>


### PR DESCRIPTION
## Summary

Adds Replit as a supported client in the README:
- One-click "Install in Replit" badge at the top (alongside existing Cursor/VS Code badges)
- `<details>` setup block with manual instructions and an auto-install deep link
- Placed between "Roo Code" and "Other Clients", consistent with existing ordering

The install link uses Replit's documented MCP install link format (`/integrations?mcp={base64}`), with payload `{"displayName":"Exa","baseUrl":"https://mcp.exa.ai/mcp"}`.

## Review & Testing Checklist for Human

- [ ] **Verify the install link works**: Click `https://replit.com/integrations?mcp=eyJkaXNwbGF5TmFtZSI6IkV4YSIsImJhc2VVcmwiOiJodHRwczovL21jcC5leGEuYWkvbWNwIn0=` while logged into Replit and confirm it pre-fills the Exa MCP server correctly
- [ ] **Verify the badge renders**: Check that `https://replit.com/badge?caption=Install%20in%20Replit` returns a valid image — Replit's badge endpoint may have changed or require specific parameters

### Notes
- The base64 payload encodes `{"displayName":"Exa","baseUrl":"https://mcp.exa.ai/mcp"}` per [Replit's MCP Install Links docs](https://docs.replit.com/replitai/mcp/install-links).
- Documentation-only change — no code or config modifications.

Link to Devin session: https://app.devin.ai/sessions/868816f876c64a8e83f68c62c754a1b5
Requested by: @10ishq
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/exa-labs/exa-mcp-server/pull/268" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
