### PR TITLE
chore: update server.json to latest MCP Registry schema

### DIFF
--- a/server.json
+++ b/server.json
@@ -1,20 +1,37 @@
 {
-  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-07-09/server.schema.json",
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.exa-labs/exa-mcp-server",
-  "description": "MCP server with Exa for web search and web crawling. Exa is the search engine for AI Applications.",
+  "title": "Exa",
+  "description": "Search the web with Exa — the search engine built for AI. Web search, code context retrieval, company research, academic paper search, competitor analysis, LinkedIn search, and web crawling.",
   "version": "3.2.0",
+  "websiteUrl": "https://exa.ai",
+  "repository": {
+    "url": "https://github.com/exa-labs/exa-mcp-server",
+    "source": "github"
+  },
   "packages": [
     {
       "registryType": "npm",
       "identifier": "exa-mcp-server",
-      "version": "3.2.0"
+      "version": "3.2.0",
+      "transport": {
+        "type": "stdio"
+      },
+      "environmentVariables": [
+        {
+          "name": "EXA_API_KEY",
+          "description": "Your Exa API key from https://dashboard.exa.ai/api-keys",
+          "isRequired": true,
+          "isSecret": true,
+          "format": "string"
+        }
+      ]
     }
   ],
   "remotes": [
     {
-      "type": "sse",
-      "url": "https://mcp.exa.ai/mcp?tools=web_search_exa,web_search_advanced_exa,get_code_context_exa,crawling_exa",
-      "description": "Hosted Exa MCP server with web search and web crawling capabilities. Get the API key from https://dashboard.exa.ai/api-keys. Customize the tools parameter to enable only specific tools (comma-separated list)."
+      "type": "streamable-http",
+      "url": "https://mcp.exa.ai/mcp"
     }
   ]
 }


### PR DESCRIPTION
## Summary

Updates `server.json` from the `2025-07-09` schema to `2025-12-11`, adding metadata fields (`title`, `websiteUrl`, `repository`) and fleshing out the npm package config with `transport` type and `environmentVariables`. Also changes the remote transport from `sse` to `streamable-http` and simplifies the remote URL by removing the hardcoded `?tools=...` query parameter.

## Review & Testing Checklist for Human

- [ ] **Verify the remote endpoint `https://mcp.exa.ai/mcp` actually supports `streamable-http` transport.** The previous value was `sse`. If the hosted server only speaks SSE, clients reading this file will fail to connect.
- [ ] **Confirm removing the `?tools=...` query params from the remote URL is intentional.** Previously only 4 tools were exposed via remote (`web_search_exa`, `web_search_advanced_exa`, `get_code_context_exa`, `crawling_exa`). The new URL exposes all tools. Verify this is desired and that all tools work correctly over the remote endpoint.
- [ ] **Verify `EXA_API_KEY` is correctly marked `isRequired: true` for the npm package.** If the local server can start without it (e.g. for health checks or with a different auth flow), this should be `false`.

### Notes
- The new schema and fields (`title`, `websiteUrl`, `repository`, `environmentVariables`) match the pattern used by other servers already listed on the GitHub MCP Registry (e.g. Firecrawl, Brightdata).
- The `description` field that was previously on the remote entry (explaining API key setup and tool customization) has been removed. Users discovering via the registry will now only see the top-level description.

Link to Devin session: https://app.devin.ai/sessions/868816f876c64a8e83f68c62c754a1b5
Requested by: @10ishq
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/exa-labs/exa-mcp-server/pull/269" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
