### PR TITLE
fix(api): strip API keys from requests before agnost analytics capture

### DIFF
--- a/api/mcp.ts
+++ b/api/mcp.ts
@@ -481,8 +481,25 @@ async function handleRequest(request: Request, options?: { forceOAuth?: boolean 
   const url = new URL(request.url);
   if (url.pathname === '/mcp' || url.pathname === '/' || url.pathname === '/mcp/oauth' || url.pathname === '/mcp-oauth' || url.pathname === '/api/mcp-oauth') {
     url.pathname = '/api/mcp';
-    request = new Request(url.toString(), request);
   }
+  
+  // Strip sensitive credentials from the request before passing to the MCP handler.
+  // Agnost analytics (trackMCP) wraps the transport and captures HTTP headers, query
+  // params, and the full URL from every request. Without sanitization, user API keys
+  // sent via x-api-key header or ?exaApiKey= query param would be forwarded to the
+  // external analytics endpoint. The API key has already been extracted into `config`
+  // above, so tools still have access to it — we just prevent it from leaking.
+  url.searchParams.delete('exaApiKey');
+  const sanitizedHeaders = new Headers(request.headers);
+  sanitizedHeaders.delete('x-api-key');
+  sanitizedHeaders.delete('authorization');
+  request = new Request(url.toString(), {
+    method: request.method,
+    headers: sanitizedHeaders,
+    body: request.body,
+    // @ts-expect-error duplex is required for streaming request bodies in undici/Node
+    duplex: 'half',
+  });
   
   // Delegate to the handler
   return handler(request);

--- a/api/mcp.ts
+++ b/api/mcp.ts
@@ -497,6 +497,7 @@ async function handleRequest(request: Request, options?: { forceOAuth?: boolean 
     method: request.method,
     headers: sanitizedHeaders,
     body: request.body,
+    signal: request.signal,
     // @ts-expect-error duplex is required for streaming request bodies in undici/Node
     duplex: 'half',
   });


### PR DESCRIPTION
## Summary

Agnost analytics (`trackMCP`) wraps the MCP transport and captures HTTP headers, query params, and the full URL from every tool call request, then sends them to `https://api.agnost.ai/api/v1/capture-event`. The `extractHttpDetails` function in agnost forwards all `x-*` prefixed headers **unredacted** — which means user API keys passed via `x-api-key` header or `?exaApiKey=` query param were being leaked to the external analytics endpoint.

**Fix:** After extracting auth config from the request (which already happens earlier in `handleRequest` via `getConfigFromRequest`), we now rebuild the request without:
- `x-api-key` header
- `authorization` header
- `exaApiKey` query param

Tools still receive the API key through `config.exaApiKey`, which is passed at handler creation time — not from the HTTP request the transport sees.

## Review & Testing Checklist for Human

- [ ] **Verify `duplex: 'half'` works in Vercel runtime** — the `new Request()` constructor needs this option for streaming request bodies (POST with JSON-RPC payload). If the Vercel edge/serverless runtime doesn't support it, tool calls will break. Test with a real tool call (e.g. `web_search_exa`) via `https://mcp.exa.ai/mcp`.
- [ ] **Confirm mcp-handler doesn't need auth headers downstream** — we strip `authorization` and `x-api-key` before passing to the handler. Verify the `mcp-handler` library and agnost don't use these for anything beyond what `getConfigFromRequest` already extracts (OAuth session handling, etc.).
- [ ] **Test all three auth methods still work end-to-end**: `x-api-key` header, `Authorization: Bearer <key>` header, and `?exaApiKey=` query param. The keys should still be extracted into config and reach tool handlers, just not leak to agnost.
- [ ] **Verify SSE/streaming still cleans up on client disconnect** — the `request.signal` is forwarded to the sanitized Request so `mcp-handler` can detect disconnections, but this should be confirmed manually.

### Notes
- The `authorization` header was already being redacted by agnost (`[REDACTED]`), but stripping it entirely is defense-in-depth.
- The URL pathname normalization logic was slightly refactored: the `new Request()` that was previously inside the pathname-match `if` block is now always executed (since we need to sanitize every request regardless of pathname).
- `request.signal` is explicitly forwarded to preserve `AbortSignal` propagation — without this, `mcp-handler`'s `createServerResponseAdapter` cannot detect client disconnections for SSE/streaming connections.
- There are no automated tests for the Vercel handler. A manual smoke test against the deployed preview is the recommended verification path.

Link to Devin session: https://app.devin.ai/sessions/e1345e4ed04944729cd456275c757da1
Requested by: @10ishq
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/exa-labs/exa-mcp-server/pull/292" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
