### PR TITLE
Remove context: fork from search skill, bump to 3.3.2

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,14 +6,14 @@
   },
   "metadata": {
     "description": "Official Exa AI plugin providing web search, code search, company research, and deep research capabilities",
-    "version": "3.3.1"
+    "version": "3.3.2"
   },
   "plugins": [
     {
       "name": "exa",
       "source": "./",
       "description": "A Model Context Protocol server with Exa for web search, code search, and web crawling. Provides real-time web searches with configurable tool selection, allowing users to enable or disable specific search capabilities.",
-      "version": "3.3.1",
+      "version": "3.3.2",
       "author": {
         "name": "Exa",
         "email": "hello@exa.ai"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "exa",
   "description": "Exa AI web search, deep research, and content extraction. Provides MCP tools and research skills for comprehensive web search, people discovery, company research, academic papers, and more.",
-  "version": "3.3.1",
+  "version": "3.3.2",
   "author": {
     "name": "Exa",
     "email": "hello@exa.ai"

--- a/skills/search/SKILL.md
+++ b/skills/search/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: search
 description: "Deep research skill using Exa search with fan-out candidate generation, domain-specific search patterns, and batched sub-agent processing. Use this skill whenever the user asks for thorough research, deep dives, comprehensive analysis, literature reviews, competitive analysis, market research, exhaustive sweeps, or any query where a single search would be insufficient. Also trigger when the user says 'research this', 'find everything about', 'find every', 'do a deep dive on', 'comprehensive overview of', or wants synthesized findings from many sources. Routes to specialized patterns for people, companies, experts, academic papers, hidden relationships, code documentation, and more. If the user wants more than a surface-level answer and the topic benefits from consulting dozens of sources, use this skill."
-context: fork
 ---
 
 # Exa Research Orchestrator


### PR DESCRIPTION
## Summary
- Removes `context: fork` from `skills/search/SKILL.md` so the search skill runs inline rather than in a forked context
- Bumps plugin version from 3.3.1 to 3.3.2

## Test plan
- [ ] Verify `/exa:search` skill runs correctly without `context: fork`
- [ ] Confirm version displays as 3.3.2 after install

🤖 Generated with [Claude Code](https://claude.com/claude-code)