### PR TITLE
[exa-mcp] Surface auth status at session start, guide users to sign in via OAuth

### DIFF
--- a/api/mcp.ts
+++ b/api/mcp.ts
@@ -82,11 +82,18 @@ function getClientIp(request: Request): string {
   return cfConnectingIp ?? xRealIp ?? xForwardedForFirst ?? 'unknown';
 }
 
-const RATE_LIMIT_ERROR_MESSAGE = `You've hit Exa's free MCP rate limit. To continue using without limits, create your own Exa API key.
+const RATE_LIMIT_ERROR_MESSAGE = `You've hit Exa's free MCP rate limit. Sign in or add an API key for unlimited access.
 
-Fix: Create API key at https://dashboard.exa.ai/api-keys , then either:
-- Set the header: Authorization: Bearer YOUR_EXA_API_KEY
-- Or use the URL: https://mcp.exa.ai/mcp?exaApiKey=YOUR_EXA_API_KEY`;
+Option 1 (recommended): Sign in with your Exa account
+  Change your MCP server URL to: https://mcp.exa.ai/mcp/oauth
+  This will open a browser window to sign in.
+
+Option 2: Use an API key
+  Get your key at https://dashboard.exa.ai/api-keys
+  Then set the header: x-api-key: YOUR_EXA_API_KEY
+  Or use the URL: https://mcp.exa.ai/mcp?exaApiKey=YOUR_EXA_API_KEY
+
+Don't have an Exa account? Create one free at https://dashboard.exa.ai`;
 
 /**
  * Create a JSON-RPC 2.0 error response for rate limiting.
@@ -366,13 +373,36 @@ async function getConfigFromRequest(request: Request): Promise<RequestConfig> {
  * configuration (tools and API key). This prevents API key leakage between
  * different users who might pass different keys via URL.
  */
-function createHandler(config: { exaApiKey?: string; enabledTools?: string[]; debug: boolean; userProvidedApiKey: boolean; exaSource?: string }) {
+/**
+ * Build server instructions that communicate auth status to the AI assistant.
+ * These instructions are sent during MCP initialization, so the assistant
+ * knows immediately whether the user is authenticated.
+ */
+function buildServerInstructions(authMethod: 'oauth' | 'api_key' | 'free_tier'): string {
+  if (authMethod === 'oauth') {
+    return 'Exa search is ready. User is signed in via OAuth with full access.';
+  }
+  if (authMethod === 'api_key') {
+    return 'Exa search is ready. User is authenticated via API key with full access.';
+  }
+
+  return [
+    'IMPORTANT: The user is NOT signed in to Exa. They are on the free tier with strict rate limits (a small number of searches per day).',
+    'Before making any Exa searches, tell the user they are not signed in and will hit rate limits quickly.',
+    'To sign in, they should change their MCP server URL from https://mcp.exa.ai/mcp to https://mcp.exa.ai/mcp/oauth — this will open a browser window to sign in with their Exa account.',
+    'Alternatively, they can get an API key at https://dashboard.exa.ai/api-keys and pass it via the x-api-key header or as a URL parameter: https://mcp.exa.ai/mcp?exaApiKey=YOUR_KEY',
+    'If they do not have an Exa account yet, they can create one for free at https://dashboard.exa.ai',
+  ].join('\n');
+}
+
+function createHandler(config: { exaApiKey?: string; enabledTools?: string[]; debug: boolean; userProvidedApiKey: boolean; authMethod: 'oauth' | 'api_key' | 'free_tier'; exaSource?: string }) {
+  const instructions = buildServerInstructions(config.authMethod);
   return createMcpHandler(
     (server: any) => {
-      initializeMcpServer(server, config);
+      initializeMcpServer(server, { ...config });
     },
-    {}, // Server options
-    { basePath: '/api' } // Config - basePath for Vercel Functions
+    { instructions },
+    { basePath: '/api' }
   );
 }
 

--- a/src/mcp-handler.ts
+++ b/src/mcp-handler.ts
@@ -35,6 +35,7 @@ export interface McpConfig {
   debug?: boolean;
   userProvidedApiKey?: boolean;
   exaSource?: string;
+  authMethod?: 'oauth' | 'api_key' | 'free_tier';
 }
 
 /**
@@ -142,6 +143,48 @@ export function initializeMcpServer(server: any, config: McpConfig = {}) {
               }
             }
           ]
+        };
+      }
+    );
+
+    // Register auth status resource so clients can check authentication state
+    const authMethod = config.authMethod || 'free_tier';
+    server.resource(
+      "auth_status",
+      "exa://auth/status",
+      {
+        mimeType: "application/json",
+        description: "Current authentication status for this Exa MCP session"
+      },
+      async () => {
+        const authenticated = authMethod !== 'free_tier';
+        const status = {
+          authenticated,
+          authMethod,
+          ...(authenticated
+            ? { message: `Authenticated via ${authMethod === 'oauth' ? 'OAuth' : 'API key'}. You have full access to Exa search.` }
+            : {
+                message: 'You are using Exa\'s free tier with rate limits. Sign in for unlimited access.',
+                signInOptions: [
+                  {
+                    method: 'oauth',
+                    description: 'Sign in with your Exa account (recommended)',
+                    instructions: 'Change your MCP server URL to https://mcp.exa.ai/mcp/oauth — your MCP client will open a browser window to sign in.',
+                  },
+                  {
+                    method: 'api_key',
+                    description: 'Use an API key',
+                    instructions: 'Get your API key at https://dashboard.exa.ai/api-keys and set the header: x-api-key: YOUR_KEY',
+                  },
+                ],
+              }),
+        };
+        return {
+          contents: [{
+            uri: "exa://auth/status",
+            text: JSON.stringify(status, null, 2),
+            mimeType: "application/json"
+          }]
         };
       }
     );

--- a/src/utils/errorHandler.ts
+++ b/src/utils/errorHandler.ts
@@ -8,9 +8,18 @@ type ToolErrorResult = { content: Array<{ type: "text"; text: string }>; isError
 
 const TRANSIENT_STATUS_CODES = new Set([500, 502, 503, 504]);
 
-const FREE_MCP_RATE_LIMIT_MESSAGE = `You've hit Exa's free MCP rate limit. To continue using without limits, create your own Exa API key.
+const FREE_MCP_RATE_LIMIT_MESSAGE = `You've hit Exa's free MCP rate limit. Sign in or add an API key for unlimited access.
 
-Fix: Create API key at https://dashboard.exa.ai/api-keys , and then update Exa MCP URL to this https://mcp.exa.ai/mcp?exaApiKey=YOUR_EXA_API_KEY`;
+Option 1 (recommended): Sign in with your Exa account
+  Change your MCP server URL to: https://mcp.exa.ai/mcp/oauth
+  This will open a browser window to sign in.
+
+Option 2: Use an API key
+  Get your key at https://dashboard.exa.ai/api-keys
+  Then set the header: x-api-key: YOUR_EXA_API_KEY
+  Or use the URL: https://mcp.exa.ai/mcp?exaApiKey=YOUR_EXA_API_KEY
+
+Don't have an Exa account? Create one free at https://dashboard.exa.ai`;
 
 /**
  * Checks if an error is a rate limit error (HTTP 429) and if the user is using the free MCP.


### PR DESCRIPTION
## Summary

When a user connects to the Exa MCP server without authentication, there is currently no indication they're on the free tier until they hit a rate limit mid-session. This PR adds proactive auth status communication so users know immediately whether they're signed in.

**Three changes:**

1. **Server instructions based on auth status** (`api/mcp.ts`): `buildServerInstructions()` generates MCP server `instructions` that are sent during the `initialize` handshake. Free-tier users get a prominent message telling the AI assistant to warn them they're unauthenticated and guide them to sign in. Authenticated users get a short confirmation.

2. **`exa://auth/status` resource** (`src/mcp-handler.ts`): New MCP resource that returns structured JSON with current auth state + sign-in options. Allows clients to programmatically query auth status.

3. **Updated rate limit error messages** (`api/mcp.ts`, `src/utils/errorHandler.ts`): Both the HTTP 429 response and tool-level error now recommend OAuth sign-in as the primary fix (change URL to `/mcp/oauth`), with API key as secondary option, and account creation link for new users.

## Review & Testing Checklist for Human

- [ ] **Verify `instructions` field is actually delivered to MCP clients**: The `instructions` string is passed via `createMcpHandler` server options → MCP SDK `ServerOptions`. Confirm this surfaces in Cursor/Claude Desktop/VS Code when connecting to a preview deploy without auth. This is the core mechanism and hasn't been runtime-tested.
- [ ] **Check the free-tier UX isn't too aggressive for first-time users**: The instructions tell the AI to warn users before every search. This is intentional per the request but could be jarring for someone just trying Exa for the first time with no account. Consider whether the tone should differ for "has account but forgot to sign in" vs "brand new user exploring."
- [ ] **Verify `/mcp/oauth` endpoint actually works end-to-end in popular MCP clients**: The instructions direct users to change their URL to `https://mcp.exa.ai/mcp/oauth`. This endpoint exists and returns 401 with `WWW-Authenticate` header pointing to `auth.exa.ai`, but it's worth confirming that Cursor, Claude Desktop, and VS Code actually handle the OAuth redirect flow correctly.
- [ ] **Near-duplicate rate limit messages**: `RATE_LIMIT_ERROR_MESSAGE` in `api/mcp.ts` and `FREE_MCP_RATE_LIMIT_MESSAGE` in `errorHandler.ts` have identical content but aren't shared. Consider whether to extract into a single constant.

### Notes
- The `{ ...config }` spread in `createHandler` is cosmetic — config is read-only in `initializeMcpServer`. No behavioral change.
- No existing tests in this repo to update; changes are compile-verified only.

Link to Devin session: https://app.devin.ai/sessions/a774746ae04c433fb28f6b648e53d978
Requested by: @scottlangille