### PR TITLE
Register skills in Claude Code plugin manifest

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -41,7 +41,8 @@
             "x-exa-source": "claude-code-plugin"
           }
         }
-      }
+      },
+      "skills": ["./skills/search"]
     }
   ]
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -15,5 +15,6 @@
         "x-exa-source": "claude-code-plugin"
       }
     }
-  }
+  },
+  "skills": ["./skills/search"]
 }


### PR DESCRIPTION
## Summary

Adds the `skills` field to both `plugin.json` and `marketplace.json` so the search skill (`skills/search/`) is included when users install the plugin via `/plugin marketplace add exa-labs/exa-mcp-server`.

Claude Code plugins default to `strict: true`, meaning only components explicitly declared in `plugin.json` are loaded. Without this field, the search skill (fan-out research orchestrator with SKILL.md + reference docs) is invisible to Claude Code despite existing in the repo.

## Review & Testing Checklist for Human

- [ ] Run `/plugin marketplace add exa-labs/exa-mcp-server` in Claude Code (pointing at this branch) and verify the search skill appears alongside the MCP server
- [ ] Confirm `./skills/search` resolves correctly relative to the plugin root (the repo root, since `source: "./"` in marketplace.json)

### Notes

The `skills/search/` directory and its contents (`SKILL.md`, `references/*.md`) are unchanged — this PR only wires them into the plugin manifest so they're discoverable.

Link to Devin session: https://app.devin.ai/sessions/65e341b3cdac466382b20d26d24d62f2
Requested by: @scottlangille