### PR TITLE
docs(skill): add MCP auth prerequisites to search skill

### DIFF
--- a/skills/search/SKILL.md
+++ b/skills/search/SKILL.md
@@ -7,22 +7,15 @@ description: "Deep research powered by Exa. Use for lead generation, literature 
 
 You are the orchestrator. Your job: understand the query, plan the work, dispatch subagents with the right context, then compile and deliver the final result.
 
-## Prerequisites: Exa MCP Auth
+## Prerequisites: Auth
 
-Before running any search, confirm the Exa MCP tools are callable. If a tool call returns an auth or rate-limit error, stop and surface the exact fix below — do not fall back to generic web search.
+Server: `https://mcp.exa.ai/mcp`.
 
-The hosted server at `https://mcp.exa.ai/mcp` accepts:
-- **Anonymous (free tier)**: no key required, but limited to ~2 QPS and ~50 requests/day per IP. This is what most clients connect as by default.
-- **Your own Exa API key**: bypasses rate limits. Get one at https://dashboard.exa.ai/api-keys, then configure it in the MCP client config one of three ways:
-  - `Authorization: Bearer YOUR_EXA_API_KEY` header
-  - `https://mcp.exa.ai/mcp?exaApiKey=YOUR_EXA_API_KEY` in the server URL
-  - `EXA_API_KEY=YOUR_EXA_API_KEY` env var (when running the `exa-mcp-server` npm package locally)
-- **OAuth** (Claude Desktop Connector, ChatGPT, any MCP client that implements OAuth 2.1 + PKCE): the client opens `auth.exa.ai` in a browser where the user signs in with Google, SSO, or email — no manual API key needed. The MCP client stores the returned bearer JWT and sends it automatically.
+1. **OAuth (recommended)** — client opens `auth.exa.ai`, user signs in with Google / SSO / email, JWT is attached automatically. No key to copy.
+2. **API key** — if OAuth isn't available, get one at https://dashboard.exa.ai/api-keys and pass it via `Authorization: Bearer …`, `?exaApiKey=…`, or `EXA_API_KEY` (local npm).
+3. **Anonymous** — works without setup but capped at ~2 QPS / ~50 req/day per IP.
 
-Symptom → fix:
-- `"You've hit Exa's free MCP rate limit"` → add a personal API key via one of the methods above.
-- `401` / `invalid token` → the configured Bearer token or `exaApiKey` is wrong or expired; regenerate at the dashboard.
-- Tool not found / server not connected → the MCP server isn't installed in this client; see the install snippets in the repo README.
+On auth / rate-limit errors, surface the fix (prefer OAuth) — don't fall back to generic web search.
 
 ## Date Calculation (Do This First)
 

--- a/skills/search/SKILL.md
+++ b/skills/search/SKILL.md
@@ -13,7 +13,7 @@ Server: `https://mcp.exa.ai/mcp`.
 
 1. **OAuth (recommended)** — client opens `auth.exa.ai`, user signs in with Google / SSO / email, JWT is attached automatically. No key to copy.
 2. **API key** — if OAuth isn't available, get one at https://dashboard.exa.ai/api-keys and pass it via `Authorization: Bearer …`, `?exaApiKey=…`, or `EXA_API_KEY` (local npm).
-3. **Anonymous** — works without setup but capped at ~2 QPS / ~50 req/day per IP.
+3. **Anonymous** — works without setup but rate-limited.
 
 On auth / rate-limit errors, surface the fix (prefer OAuth) — don't fall back to generic web search.
 

--- a/skills/search/SKILL.md
+++ b/skills/search/SKILL.md
@@ -17,7 +17,7 @@ The hosted server at `https://mcp.exa.ai/mcp` accepts:
   - `Authorization: Bearer YOUR_EXA_API_KEY` header
   - `https://mcp.exa.ai/mcp?exaApiKey=YOUR_EXA_API_KEY` in the server URL
   - `EXA_API_KEY=YOUR_EXA_API_KEY` env var (when running the `exa-mcp-server` npm package locally)
-- **OAuth** (Claude Desktop Connector, etc.): handled automatically by the client — no key needed.
+- **OAuth** (Claude Desktop Connector, ChatGPT, any MCP client that implements OAuth 2.1 + PKCE): the client opens `auth.exa.ai` in a browser where the user signs in with Google, SSO, or email — no manual API key needed. The MCP client stores the returned bearer JWT and sends it automatically.
 
 Symptom → fix:
 - `"You've hit Exa's free MCP rate limit"` → add a personal API key via one of the methods above.

--- a/skills/search/SKILL.md
+++ b/skills/search/SKILL.md
@@ -7,6 +7,23 @@ description: "Deep research powered by Exa. Use for lead generation, literature 
 
 You are the orchestrator. Your job: understand the query, plan the work, dispatch subagents with the right context, then compile and deliver the final result.
 
+## Prerequisites: Exa MCP Auth
+
+Before running any search, confirm the Exa MCP tools are callable. If a tool call returns an auth or rate-limit error, stop and surface the exact fix below — do not fall back to generic web search.
+
+The hosted server at `https://mcp.exa.ai/mcp` accepts:
+- **Anonymous (free tier)**: no key required, but limited to ~2 QPS and ~50 requests/day per IP. This is what most clients connect as by default.
+- **Your own Exa API key**: bypasses rate limits. Get one at https://dashboard.exa.ai/api-keys, then configure it in the MCP client config one of three ways:
+  - `Authorization: Bearer YOUR_EXA_API_KEY` header
+  - `https://mcp.exa.ai/mcp?exaApiKey=YOUR_EXA_API_KEY` in the server URL
+  - `EXA_API_KEY=YOUR_EXA_API_KEY` env var (when running the `exa-mcp-server` npm package locally)
+- **OAuth** (Claude Desktop Connector, etc.): handled automatically by the client — no key needed.
+
+Symptom → fix:
+- `"You've hit Exa's free MCP rate limit"` → add a personal API key via one of the methods above.
+- `401` / `invalid token` → the configured Bearer token or `exaApiKey` is wrong or expired; regenerate at the dashboard.
+- Tool not found / server not connected → the MCP server isn't installed in this client; see the install snippets in the repo README.
+
 ## Date Calculation (Do This First)
 
 If the query involves time ("last week", "recent", "past 6 months"), calculate exact dates from today's date in your environment context. Write out the calculation explicitly before doing anything else. Never eyeball dates or reuse dates from examples.


### PR DESCRIPTION
## Summary
Adds a short "Prerequisites: Auth" block near the top of `skills/search/SKILL.md`. The skill previously assumed the Exa MCP tools were already callable and gave no guidance when they weren't — so a user hitting a rate limit or misconfigured key would just see a confusing tool error and potentially fall back to generic web search.

New block (5 lines) prioritizes OAuth and lists fallbacks:
1. **OAuth (recommended)** — `auth.exa.ai` handles Google / SSO / email sign-in; client attaches the JWT automatically.
2. **API key** — `Authorization: Bearer`, `?exaApiKey=` query param, or `EXA_API_KEY` env var (local npm).
3. **Anonymous** — works without setup but rate-limited.

Plus a one-liner telling the orchestrator to surface the fix (prefer OAuth) on auth / rate-limit errors instead of silently falling back.

## Review & Testing Checklist for Human
- [ ] Confirm the wording of the OAuth bullet matches how you'd describe the flow externally (Google / SSO / email sign-in via `auth.exa.ai`).
- [ ] Confirm there's nothing else you want callers to know up-front (e.g. specific client install links).

### Notes
- No code changes, skill-file-only edit.
- Did not touch `references/`.

Link to Devin session: https://app.devin.ai/sessions/25db41776ada4a5f9d2703d679b9f07c
Requested by: @JakubHojsan