### PR TITLE
fix(rate-limit): apply rate limits consistently to all non-user-keyed requests

### DIFF
--- a/api/mcp.ts
+++ b/api/mcp.ts
@@ -459,6 +459,8 @@ async function handleRequest(request: Request, options?: { forceOAuth?: boolean 
   // Use separate API key for bypass users and save their IP/user-agent for tracking
   if (bypassRateLimit) {
     config.exaApiKey = bypassApiKey;
+    // Bypass path is treated as "no user key" for rate-limiting purposes.
+    config.userProvidedApiKey = false;
     const clientIp = getClientIp(request);
     saveBypassRequestInfo(clientIp, userAgent, config.debug);
   }


### PR DESCRIPTION
Ensures that the rate-limit predicate correctly classifies bypass-tier traffic.