### PR TITLE
Use highlights: true instead of maxCharacters: 2000 in web_search_exa

### DIFF
--- a/src/tools/webSearch.ts
+++ b/src/tools/webSearch.ts
@@ -51,7 +51,7 @@ export function registerWebSearchTool(server: McpServer, config?: { exaApiKey?: 
           numResults: numResults || API_CONFIG.DEFAULT_NUM_RESULTS,
           ...(category && { category }),
           contents: {
-            highlights: { query: cleanedQuery, maxCharacters: 2000 },
+            highlights: true,
           },
         };
 

--- a/tests/fixtures/exaResponses.ts
+++ b/tests/fixtures/exaResponses.ts
@@ -2,7 +2,7 @@ import type { SearchResponse } from "exa-js";
 import type { ExaContentsResponse, ExaSearchResponse } from "../../src/types.js";
 
 type WebSearchFixtureResponse = ExaSearchResponse &
-  SearchResponse<{ highlights: { query: string; maxCharacters: number } }>;
+  SearchResponse<{ highlights: true }>;
 
 type WebContentsFixtureResponse = ExaContentsResponse &
   SearchResponse<{ text: { maxCharacters: number } }>;

--- a/tests/unit/tools/webSearch.test.ts
+++ b/tests/unit/tools/webSearch.test.ts
@@ -60,7 +60,7 @@ describe("registerWebSearchTool", () => {
         numResults: 2,
         category: "news",
         contents: {
-          highlights: { query: "AI breakthroughs", maxCharacters: 2000 },
+          highlights: true,
         },
       },
       undefined,


### PR DESCRIPTION
## Summary
Updates `web_search_exa` to request `contents.highlights: true` from the Exa API instead of the previous `{ query: cleanedQuery, maxCharacters: 2000 }` form. This lets Exa return its default highlight selection rather than capping at 2000 characters.

Changes:
- `src/tools/webSearch.ts`: swap `highlights: { query: cleanedQuery, maxCharacters: 2000 }` for `highlights: true`.
- `tests/unit/tools/webSearch.test.ts`: update expected request payload.
- `tests/fixtures/exaResponses.ts`: update fixture response type to match `{ highlights: true }`.

The `ExaSearchRequest.contents.highlights` type already accepts `boolean`, so no type changes are required.

## Review & Testing Checklist for Human
- [x] Confirm `highlights: true` is the desired payload shape (vs. e.g. `{}` or omitting `query`/`maxCharacters` while keeping object form).
- [ ] Spot-check a real `web_search_exa` call to verify highlights still come back in the response and are rendered in the formatted output.

### Notes
- No changes to other tools (`webSearchAdvanced`, `deepSearch`, `exaCode`, `webFetch`) — they use `maxCharacters` for different purposes (text extraction, deep search highlights, etc.) and weren't part of this request.
- `npm run ci` (typecheck + vitest) passes locally.

Link to Devin session: https://app.devin.ai/sessions/de320cd3bac84ecda2acfe18de4ba892
Requested by: @scottlangille