### PR TITLE
fix(mcp): return 401 when Bearer JWT fails OAuth verification

### DIFF
--- a/api/mcp.ts
+++ b/api/mcp.ts
@@ -300,6 +300,8 @@ interface RequestConfig {
   exaSource?: string;
   mcpSessionId?: string;
   defaultSearchType?: 'auto' | 'fast';
+  /** True when a Bearer token was a JWT but failed OAuth verification (expired, bad sig, wrong issuer/audience). */
+  invalidOAuthJwt: boolean;
 }
 
 /**
@@ -313,6 +315,7 @@ async function getConfigFromRequest(request: Request): Promise<RequestConfig> {
   let userProvidedApiKey = false;
   let authMethod: 'oauth' | 'api_key' | 'free_tier' = 'free_tier';
   let defaultSearchType: 'auto' | 'fast' | undefined;
+  let invalidOAuthJwt = false;
 
   // 1. Check x-api-key header (highest priority)
   const xApiKey = request.headers.get('x-api-key');
@@ -335,7 +338,10 @@ async function getConfigFromRequest(request: Request): Promise<RequestConfig> {
           userProvidedApiKey = true;
           authMethod = 'oauth';
         } else {
-          // JWT verification failed — don't fall through to treating it as an API key
+          // JWT verification failed — flag so the caller can return 401 with
+          // a WWW-Authenticate challenge instead of silently falling through to
+          // the env API key or free tier.
+          invalidOAuthJwt = true;
           console.error('[EXA-MCP] Invalid OAuth JWT token');
         }
       } else {
@@ -402,7 +408,7 @@ async function getConfigFromRequest(request: Request): Promise<RequestConfig> {
   const exaSource = request.headers.get('x-exa-source') || undefined;
   const mcpSessionId = request.headers.get('MCP-Session-Id') || undefined;
 
-  return { exaApiKey, enabledTools, debug, userProvidedApiKey, authMethod, exaSource, mcpSessionId, defaultSearchType };
+  return { exaApiKey, enabledTools, debug, userProvidedApiKey, authMethod, exaSource, mcpSessionId, defaultSearchType, invalidOAuthJwt };
 }
 
 /**
@@ -503,7 +509,15 @@ async function processRequest(request: Request, options?: { forceOAuth?: boolean
 
   // Extract configuration from request headers, URL, and env vars
   const config = await getConfigFromRequest(request);
-  
+
+  // A Bearer JWT that fails verification (expired, bad signature, wrong issuer/audience)
+  // must produce a 401 + WWW-Authenticate challenge so the client knows to refresh or
+  // re-authenticate. Falling through to the env API key or free tier would mask the
+  // expired-credential signal and prevent the client's refresh flow from triggering.
+  if (config.invalidOAuthJwt) {
+    return create401Response();
+  }
+
   if (config.debug) {
     console.log(`[EXA-MCP] Request URL: ${request.url}`);
     console.log(`[EXA-MCP] Enabled tools: ${config.enabledTools?.join(', ') || 'default'}`);

--- a/tests/unit/api/mcp.test.ts
+++ b/tests/unit/api/mcp.test.ts
@@ -247,11 +247,11 @@ describe("api/mcp handler", () => {
     });
   });
 
-  it("does not treat invalid OAuth JWTs as plain API keys", async () => {
+  it("returns 401 with WWW-Authenticate when a Bearer JWT fails verification", async () => {
     process.env.EXA_API_KEY = "env-key";
     verifyOAuthTokenMock.mockResolvedValue(null);
 
-    const { config } = await callHandleRequest(
+    const { response, config } = await callHandleRequest(
       new Request("https://mcp.exa.ai/mcp", {
         headers: {
           authorization: "Bearer invalid-jwt",
@@ -260,11 +260,33 @@ describe("api/mcp handler", () => {
     );
 
     expect(verifyOAuthTokenMock).toHaveBeenCalledWith("invalid-jwt");
-    expect(config).toMatchObject({
-      exaApiKey: "env-key",
-      userProvidedApiKey: false,
-      authMethod: "free_tier",
-    });
+    expect(response.status).toBe(401);
+    expect(response.headers.get("WWW-Authenticate")).toContain(
+      'resource_metadata="https://mcp.exa.ai/.well-known/oauth-protected-resource"',
+    );
+    expectMcpCorsHeaders(response);
+    expect(config).toBeUndefined();
+    expect(initializeMcpServerMock).not.toHaveBeenCalled();
+  });
+
+  it("returns 401 for plugin clients sending an invalid OAuth JWT", async () => {
+    verifyOAuthTokenMock.mockResolvedValue(null);
+
+    const { response } = await callHandleRequest(
+      new Request("https://mcp.exa.ai/mcp?client=claude-code-plugin", {
+        headers: {
+          authorization: "Bearer invalid-jwt",
+        },
+      }),
+    );
+
+    expect(verifyOAuthTokenMock).toHaveBeenCalledWith("invalid-jwt");
+    expect(response.status).toBe(401);
+    expect(response.headers.get("WWW-Authenticate")).toContain(
+      'resource_metadata="https://mcp.exa.ai/.well-known/oauth-protected-resource"',
+    );
+    expectMcpCorsHeaders(response);
+    expect(initializeMcpServerMock).not.toHaveBeenCalled();
   });
 
   it("uses exaApiKey query parameters when no key header is present", async () => {


### PR DESCRIPTION
## Summary

- When `Authorization: Bearer <jwt>` is sent and the JWT fails OAuth verification (expired, bad signature, wrong issuer/audience), `getConfigFromRequest` in `api/mcp.ts` logs the failure and silently falls back to `process.env.EXA_API_KEY` or free-tier handling.
- The request returns 200 with degraded behavior instead of a 401 + `WWW-Authenticate` challenge, so clients have no signal to refresh the token or surface a re-auth flow. The symptom typically manifests as unexpected free-tier rate-limit responses instead of an auth error.
- This change surfaces JWT verification failures as the same 401 + `WWW-Authenticate: Bearer resource_metadata=...` response used when no auth is presented at all.

## Test plan

- [x] `npm run typecheck`
- [x] `npm test` (81/81 passing)
- [x] Updated existing test in `tests/unit/api/mcp.test.ts` that pinned the fall-through behavior to assert the new 401 response
- [x] Added a positive test: `?client=claude-code-plugin` + invalid JWT → 401 with `WWW-Authenticate`
- [ ] Manual: send an expired/forged JWT to `/mcp` and confirm `HTTP 401` with the `WWW-Authenticate` header pointing at `/.well-known/oauth-protected-resource`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/exa-labs/exa-mcp-server/pull/335" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->