### PR TITLE
fix(mcp): include error="invalid_token" in WWW-Authenticate on JWT failure

### DIFF
--- a/api/mcp.ts
+++ b/api/mcp.ts
@@ -439,21 +439,41 @@ function hasAuth(request: Request): boolean {
   return false;
 }
 
-function create401Response(): Response {
+/**
+ * Build a 401 Unauthorized response with an OAuth `Bearer` challenge.
+ *
+ * `reason` controls the `WWW-Authenticate` parameters per RFC 6750 §3:
+ * - 'missing'        — no credentials were presented; advertise the resource so the client can start a flow.
+ * - 'invalid_token'  — a token was presented but failed verification; include `error="invalid_token"` so the
+ *                      client can distinguish "refresh/re-auth" from "start over from scratch" and trigger its
+ *                      refresh-token exchange against the authorization server.
+ */
+function create401Response(reason: 'missing' | 'invalid_token' = 'missing'): Response {
+  const params: string[] = [];
+  if (reason === 'invalid_token') {
+    params.push('error="invalid_token"');
+    params.push('error_description="The access token is invalid or expired"');
+  }
+  params.push('resource_metadata="https://mcp.exa.ai/.well-known/oauth-protected-resource"');
+
+  const message =
+    reason === 'invalid_token'
+      ? 'The access token is invalid or expired. Refresh or re-authenticate.'
+      : 'Authentication required. Use OAuth or provide an API key.';
+
   return new Response(
     JSON.stringify({
       jsonrpc: '2.0',
       error: {
         code: -32000,
-        message: 'Authentication required. Use OAuth or provide an API key.',
+        message,
       },
       id: null,
     }),
     {
       status: 401,
       headers: {
-        'WWW-Authenticate':
-          'Bearer resource_metadata="https://mcp.exa.ai/.well-known/oauth-protected-resource"',
+        'WWW-Authenticate': `Bearer ${params.join(', ')}`,
         'Content-Type': 'application/json',
         ...CORS_HEADERS,
       },
@@ -514,8 +534,10 @@ async function processRequest(request: Request, options?: { forceOAuth?: boolean
   // must produce a 401 + WWW-Authenticate challenge so the client knows to refresh or
   // re-authenticate. Falling through to the env API key or free tier would mask the
   // expired-credential signal and prevent the client's refresh flow from triggering.
+  // Use the `invalid_token` reason so the WWW-Authenticate header carries the standard
+  // OAuth error code that clients listen for when deciding to exchange a refresh token.
   if (config.invalidOAuthJwt) {
-    return create401Response();
+    return create401Response('invalid_token');
   }
 
   if (config.debug) {

--- a/tests/unit/api/mcp.test.ts
+++ b/tests/unit/api/mcp.test.ts
@@ -247,7 +247,7 @@ describe("api/mcp handler", () => {
     });
   });
 
-  it("returns 401 with WWW-Authenticate when a Bearer JWT fails verification", async () => {
+  it("returns 401 with invalid_token WWW-Authenticate when a Bearer JWT fails verification", async () => {
     process.env.EXA_API_KEY = "env-key";
     verifyOAuthTokenMock.mockResolvedValue(null);
 
@@ -261,7 +261,10 @@ describe("api/mcp handler", () => {
 
     expect(verifyOAuthTokenMock).toHaveBeenCalledWith("invalid-jwt");
     expect(response.status).toBe(401);
-    expect(response.headers.get("WWW-Authenticate")).toContain(
+    const wwwAuthenticate = response.headers.get("WWW-Authenticate");
+    expect(wwwAuthenticate).toContain('error="invalid_token"');
+    expect(wwwAuthenticate).toContain('error_description="The access token is invalid or expired"');
+    expect(wwwAuthenticate).toContain(
       'resource_metadata="https://mcp.exa.ai/.well-known/oauth-protected-resource"',
     );
     expectMcpCorsHeaders(response);
@@ -269,7 +272,7 @@ describe("api/mcp handler", () => {
     expect(initializeMcpServerMock).not.toHaveBeenCalled();
   });
 
-  it("returns 401 for plugin clients sending an invalid OAuth JWT", async () => {
+  it("returns 401 with invalid_token error for plugin clients sending an invalid OAuth JWT", async () => {
     verifyOAuthTokenMock.mockResolvedValue(null);
 
     const { response } = await callHandleRequest(
@@ -282,7 +285,9 @@ describe("api/mcp handler", () => {
 
     expect(verifyOAuthTokenMock).toHaveBeenCalledWith("invalid-jwt");
     expect(response.status).toBe(401);
-    expect(response.headers.get("WWW-Authenticate")).toContain(
+    const wwwAuthenticate = response.headers.get("WWW-Authenticate");
+    expect(wwwAuthenticate).toContain('error="invalid_token"');
+    expect(wwwAuthenticate).toContain(
       'resource_metadata="https://mcp.exa.ai/.well-known/oauth-protected-resource"',
     );
     expectMcpCorsHeaders(response);


### PR DESCRIPTION
## Summary

- Follow-up to #336. When a Bearer JWT fails OAuth verification, the 401 response sent the same generic `WWW-Authenticate` header used when no credentials are presented at all (`Bearer resource_metadata="..."`).
- Per [RFC 6750 §3.1](https://datatracker.ietf.org/doc/html/rfc6750#section-3.1), an invalid-token 401 should explicitly include `error="invalid_token"` so OAuth-aware clients can distinguish "your token is bad — refresh it against the authorization server" from "you have no credentials — start a fresh authorization flow". Without that parameter the signal is ambiguous and a well-behaved client has no unambiguous trigger to perform the refresh-token exchange.
- This PR adds the standard error parameters to the JWT-failure path only. The missing-credentials path keeps the existing generic challenge — `error="invalid_token"` would be incorrect there.

### Header change

Invalid-JWT response (was → now):

```
WWW-Authenticate: Bearer resource_metadata="https://mcp.exa.ai/.well-known/oauth-protected-resource"
```

```
WWW-Authenticate: Bearer error="invalid_token", error_description="The access token is invalid or expired", resource_metadata="https://mcp.exa.ai/.well-known/oauth-protected-resource"
```

Missing-credentials response: unchanged.

## Caveat

The server can only send the standard signal — whether a specific client *acts* on it by exchanging its refresh token is upstream behavior. This PR makes the signal as RFC-correct and unambiguous as possible so any spec-compliant OAuth client has what it needs.

## Test plan

- [x] `npm run typecheck`
- [x] `npm test` (81/81 passing)
- [x] Updated invalid-JWT tests in `tests/unit/api/mcp.test.ts` to assert `error="invalid_token"` and `error_description` are present in `WWW-Authenticate`
- [x] Existing missing-credentials 401 tests still pass — confirms they keep the generic challenge

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/exa-labs/exa-mcp-server/pull/337" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->