### PR TITLE
fix(web-search-advanced): make text content opt-in, default to highlights

### DIFF
--- a/src/tools/webSearchAdvanced.ts
+++ b/src/tools/webSearchAdvanced.ts
@@ -16,7 +16,7 @@ export function registerWebSearchAdvancedTool(server: McpServer, config?: { exaA
 
 Best for: When you need specific filters like date ranges, domain restrictions, or category filters.
 Not recommended for: Simple searches - use web_search_exa instead.
-Returns: Search results with optional highlights, summaries, and subpage content.`,
+Returns: Search results. Defaults to highlights only (token-efficient, recommended for agents). Set enableText for full page text, enableSummary for AI summaries, or combine modes as needed.`,
     {
       query: lenientString().describe("Search query - can be a question, statement, or keywords"),
       numResults: lenientOptionalNumber().describe("Number of results (1-100, default: 10)"),
@@ -41,7 +41,8 @@ Returns: Search results with optional highlights, summaries, and subpage content
 
       additionalQueries: z.array(z.string()).optional().describe("Additional query variations to expand search coverage"),
 
-      textMaxCharacters: lenientOptionalPositiveNumber().describe("Max characters for text extraction per result"),
+      enableText: lenientOptionalBoolean().describe("Include full page text per result. Off by default — for most agent workflows, prefer enableHighlights (token-efficient). Use enableText for deep analysis when you need full content."),
+      textMaxCharacters: lenientOptionalPositiveNumber().describe("Max characters for text extraction per result. Requires enableText: true (without it, this value is ignored)."),
       contextMaxCharacters: lenientOptionalPositiveNumber().describe("Max characters for context string (not included by default)"),
 
       enableSummary: lenientOptionalBoolean().describe("Enable summary generation for results"),
@@ -75,10 +76,13 @@ Returns: Search results with optional highlights, summaries, and subpage content
         const exa = new Exa(config?.exaApiKey || process.env.EXA_API_KEY || '');
 
         const contents: ExaAdvancedSearchRequest['contents'] = {
-          text: params.textMaxCharacters ? { maxCharacters: params.textMaxCharacters } : true,
           ...(params.maxAgeHours !== undefined ? { maxAgeHours: params.maxAgeHours } : { livecrawl: 'fallback' as const }),
           ...(params.livecrawlTimeout && { livecrawlTimeout: params.livecrawlTimeout }),
         };
+
+        if (params.enableText) {
+          contents.text = params.textMaxCharacters ? { maxCharacters: params.textMaxCharacters } : true;
+        }
 
         if (params.contextMaxCharacters) {
           contents.context = { maxCharacters: params.contextMaxCharacters };
@@ -95,6 +99,12 @@ Returns: Search results with optional highlights, summaries, and subpage content
             highlightsPerUrl: params.highlightsPerUrl,
             query: params.highlightsQuery,
           };
+        }
+
+        // Default to highlights when no content mode was explicitly requested.
+        // Matches web_search_exa and Exa's own guidance for agent workflows.
+        if (!params.enableText && !params.enableSummary && !params.enableHighlights && !params.contextMaxCharacters) {
+          contents.highlights = true;
         }
 
         if (params.subpages) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -61,7 +61,7 @@ export interface ExaAdvancedSearchRequest {
       numSentences?: number;
       highlightsPerUrl?: number;
       query?: string;
-    };
+    } | boolean;
     livecrawl?: 'never' | 'fallback' | 'always' | 'preferred';
     maxAgeHours?: number;
     livecrawlTimeout?: number;

--- a/tests/unit/tools/webSearchAdvanced.test.ts
+++ b/tests/unit/tools/webSearchAdvanced.test.ts
@@ -1,0 +1,69 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { searchResponse } from "../../fixtures/exaResponses.js";
+import { FakeMcpServer } from "../../helpers/fakeMcpServer.js";
+
+const { ExaMock, requestMock } = vi.hoisted(() => {
+  const requestMock = vi.fn();
+  class ExaMock {
+    request = requestMock;
+  }
+  return { ExaMock, requestMock };
+});
+
+vi.mock("exa-js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("exa-js")>()),
+  Exa: ExaMock,
+}));
+
+vi.mock("agnost", () => ({
+  checkpoint: vi.fn(),
+}));
+
+describe("registerWebSearchAdvancedTool", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+  });
+
+  it("defaults to highlights only and omits text when no content mode is requested", async () => {
+    const { registerWebSearchAdvancedTool } = await import(
+      "../../../src/tools/webSearchAdvanced.js"
+    );
+    const server = new FakeMcpServer();
+    requestMock.mockResolvedValue(searchResponse);
+
+    registerWebSearchAdvancedTool(server as any, { exaApiKey: "test-key" });
+
+    await server.getTool("web_search_advanced_exa").handler({
+      query: "AI breakthroughs",
+    });
+
+    expect(requestMock).toHaveBeenCalledTimes(1);
+    const sentBody = requestMock.mock.calls[0][2];
+    expect(sentBody.contents).toEqual({
+      livecrawl: "fallback",
+      highlights: true,
+    });
+  });
+
+  it("opts into text via enableText without falling back to default highlights", async () => {
+    const { registerWebSearchAdvancedTool } = await import(
+      "../../../src/tools/webSearchAdvanced.js"
+    );
+    const server = new FakeMcpServer();
+    requestMock.mockResolvedValue(searchResponse);
+
+    registerWebSearchAdvancedTool(server as any, { exaApiKey: "test-key" });
+
+    await server.getTool("web_search_advanced_exa").handler({
+      query: "AI breakthroughs",
+      enableText: true,
+    });
+
+    const sentBody = requestMock.mock.calls[0][2];
+    expect(sentBody.contents).toEqual({
+      livecrawl: "fallback",
+      text: true,
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- The `web_search_advanced_exa` tool unconditionally set `contents.text = true` in every Exa search request, so every result included full page text. The only way to suppress it was `textMaxCharacters: 1`, which still returned a 1-character `text` field on each result — token-wasteful and an awkward escape hatch.
- This was inconsistent with two things:
  - The sibling `web_search_exa` tool, which sends `contents: { highlights: true }` and has no text knob.
  - Exa's own [Contents Best Practices](https://docs.exa.ai/reference/contents-best-practices) guide: *"Use highlights for agentic workflows: When building multi-step agents that make repeated content extraction calls, highlights provide the most relevant excerpts without flooding context windows."*
- After this change, `web_search_advanced_exa` follows the same default as `web_search_exa` — highlights only — and full text becomes an explicit opt-in via a new `enableText` parameter (parallel to the existing `enableSummary` and `enableHighlights`).

## Changes

- Add `enableText: boolean` parameter. Off by default.
- Remove the unconditional `text: true` from the contents block. Text is only requested when `enableText` is set.
- When no content mode is requested, default `contents.highlights = true`. This matches `web_search_exa` and Exa's published guidance for agent workflows.
- Update the `textMaxCharacters` description to note it requires `enableText: true` — consistent with how `summaryQuery` requires `enableSummary` and `highlightsMaxCharacters` requires `enableHighlights` (both siblings already silent-drop without their parent flag).
- Widen `ExaAdvancedSearchRequest.contents.highlights` to `{...} | boolean` to allow `true` as the new default. The API supports this; the sibling `ExaSearchRequest.contents.highlights` type already allowed it.

## Behavior change

This is a behavior change for existing callers of `web_search_advanced_exa`:

- Before: every search returned full page text by default.
- After: returns highlights only by default. Set `enableText: true` to restore the old behavior.

`web_search_advanced_exa` is `enabled: false` in the default tool registry (`src/mcp-handler.ts`), so only callers who have explicitly enabled the tool are affected.

## Test plan

- [x] `npm run ci` — typecheck clean, 83 tests passing.
- [x] New file `tests/unit/tools/webSearchAdvanced.test.ts` covers:
  - Default call (just `query`) → `contents: { livecrawl: "fallback", highlights: true }`, no `text` field.
  - `enableText: true` → `contents: { livecrawl: "fallback", text: true }`, no implicit highlights.