### PR TITLE
[mcp]: align OAuth protected resource metadata

### DIFF
--- a/api/mcp.ts
+++ b/api/mcp.ts
@@ -509,13 +509,15 @@ function hasAuth(request: Request): boolean {
  *                      client can distinguish "refresh/re-auth" from "start over from scratch" and trigger its
  *                      refresh-token exchange against the authorization server.
  */
+const PROTECTED_RESOURCE_METADATA_URL = 'https://mcp.exa.ai/.well-known/oauth-protected-resource/mcp';
+
 function create401Response(reason: 'missing' | 'invalid_token' = 'missing'): Response {
   const params: string[] = [];
   if (reason === 'invalid_token') {
     params.push('error="invalid_token"');
     params.push('error_description="The access token is invalid or expired"');
   }
-  params.push('resource_metadata="https://mcp.exa.ai/.well-known/oauth-protected-resource"');
+  params.push(`resource_metadata="${PROTECTED_RESOURCE_METADATA_URL}"`);
 
   const message =
     reason === 'invalid_token'

--- a/api/well-known-oauth-protected-resource.ts
+++ b/api/well-known-oauth-protected-resource.ts
@@ -9,7 +9,7 @@ const OAUTH_ISSUER = process.env.OAUTH_ISSUER || 'https://auth.exa.ai';
 
 export function GET(): Response {
   const metadata = {
-    resource: 'https://mcp.exa.ai',
+    resource: 'https://mcp.exa.ai/mcp',
     authorization_servers: [OAUTH_ISSUER],
     scopes_supported: ['mcp:tools'],
     bearer_methods_supported: ['header'],

--- a/tests/unit/api/mcp.test.ts
+++ b/tests/unit/api/mcp.test.ts
@@ -387,7 +387,7 @@ describe("api/mcp handler", () => {
     expect(wwwAuthenticate).toContain('error="invalid_token"');
     expect(wwwAuthenticate).toContain('error_description="The access token is invalid or expired"');
     expect(wwwAuthenticate).toContain(
-      'resource_metadata="https://mcp.exa.ai/.well-known/oauth-protected-resource"',
+      'resource_metadata="https://mcp.exa.ai/.well-known/oauth-protected-resource/mcp"',
     );
     expectMcpCorsHeaders(response);
     expect(config).toBeUndefined();
@@ -410,7 +410,7 @@ describe("api/mcp handler", () => {
     const wwwAuthenticate = response.headers.get("WWW-Authenticate");
     expect(wwwAuthenticate).toContain('error="invalid_token"');
     expect(wwwAuthenticate).toContain(
-      'resource_metadata="https://mcp.exa.ai/.well-known/oauth-protected-resource"',
+      'resource_metadata="https://mcp.exa.ai/.well-known/oauth-protected-resource/mcp"',
     );
     expectMcpCorsHeaders(response);
     expect(initializeMcpServerMock).not.toHaveBeenCalled();
@@ -509,7 +509,7 @@ describe("api/mcp handler", () => {
 
     expect(response.status).toBe(401);
     expect(response.headers.get("WWW-Authenticate")).toContain(
-      'resource_metadata="https://mcp.exa.ai/.well-known/oauth-protected-resource"',
+      'resource_metadata="https://mcp.exa.ai/.well-known/oauth-protected-resource/mcp"',
     );
     expectMcpCorsHeaders(response);
   });
@@ -549,5 +549,19 @@ describe("api/mcp handler", () => {
     expect(response.status).toBe(500);
     expect(response.headers.get("Content-Type")).toContain("application/json");
     expectMcpCorsHeaders(response);
+  });
+
+  it("serves OAuth protected resource metadata for the MCP resource", async () => {
+    const { GET } = await import("../../../api/well-known-oauth-protected-resource.js");
+
+    const response = GET();
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      resource: "https://mcp.exa.ai/mcp",
+      authorization_servers: ["https://auth.exa.ai"],
+      scopes_supported: ["mcp:tools"],
+      bearer_methods_supported: ["header"],
+    });
   });
 });

--- a/vercel.json
+++ b/vercel.json
@@ -27,6 +27,10 @@
       "destination": "/api/well-known-oauth-protected-resource"
     },
     {
+      "source": "/.well-known/oauth-protected-resource/:path*",
+      "destination": "/api/well-known-oauth-protected-resource"
+    },
+    {
       "source": "/.well-known/openai-apps-challenge",
       "destination": "/api/well-known-openai-apps-challenge"
     },


### PR DESCRIPTION
## Summary
Updates OAuth protected-resource discovery to point at the actual MCP resource path:

- `WWW-Authenticate` now advertises `https://mcp.exa.ai/.well-known/oauth-protected-resource/mcp`
- protected resource metadata now reports `resource: "https://mcp.exa.ai/mcp"`
- Vercel rewrites now serve path-suffixed protected-resource metadata URLs
- adds unit coverage for the metadata response and updated OAuth challenge headers

This keeps Exa MCP aligned with RFC 9728 / Claude connector examples for resources with a path component.

## Review & Testing Checklist for Human
- [ ] Confirm Claude Code expects/accepts the path-suffixed metadata URL for the hosted `/mcp` endpoint.
- [ ] Verify the Vercel rewrite serves `/.well-known/oauth-protected-resource/mcp` in preview/prod.
- [ ] End-to-end test: connect Exa MCP in Claude Code, let or force the access token expire, and confirm the client refreshes or re-auths via the OAuth challenge path rather than silently falling back.

### Notes
Local checks run:
- `npm run typecheck`
- `npm run test -- tests/unit/api/mcp.test.ts`

Link to Devin session: https://app.devin.ai/sessions/438719b3455b4de7863af0f2f85db737
Requested by: @jeffzwang