### PR TITLE
[exa-mcp-server]: set server name to 'Exa' and add icon

### DIFF
--- a/api/mcp.ts
+++ b/api/mcp.ts
@@ -2,6 +2,7 @@ process.env.AGNOST_LOG_LEVEL = 'error';
 
 import { randomUUID } from 'node:crypto';
 import { createMcpHandler } from 'mcp-handler';
+import type { Implementation } from '@modelcontextprotocol/sdk/types.js';
 import { initializeMcpServer } from '../src/mcp-handler.js';
 import { Ratelimit } from '@upstash/ratelimit';
 import { Redis } from '@upstash/redis';
@@ -483,7 +484,17 @@ function createHandler(config: { exaApiKey?: string; enabledTools?: string[]; de
     (server: any) => {
       initializeMcpServer(server, config);
     },
-    {}, // Server options
+    {
+      serverInfo: {
+        name: 'exa-search-server',
+        title: 'Exa',
+        version: '3.2.1',
+        websiteUrl: 'https://exa.ai',
+        icons: [
+          { src: 'https://exa.ai/images/favicon-32x32.png', mimeType: 'image/png', sizes: ['32x32'] },
+        ],
+      } satisfies Implementation as { name: string; version: string },
+    },
     { basePath: '/api' } // Config - basePath for Vercel Functions
   );
 }

--- a/src/stdio.ts
+++ b/src/stdio.ts
@@ -39,7 +39,11 @@ export async function main(env: NodeJS.ProcessEnv = process.env): Promise<void> 
   const server = new McpServer({
     name: "exa-search-server",
     title: "Exa",
-    version: "3.2.1"
+    version: "3.2.1",
+    websiteUrl: "https://exa.ai",
+    icons: [
+      { src: "https://exa.ai/images/favicon-32x32.png", mimeType: "image/png", sizes: ["32x32"] },
+    ],
   });
 
   initializeMcpServer(server, config);


### PR DESCRIPTION
## Summary

MCP clients (e.g. MCP Inspector, Cursor) were showing `mcp-typescript server on vercel` as the server name because `api/mcp.ts` passed empty `{}` as server options to `createMcpHandler`, which defaults to that generic name.

This PR sets proper `serverInfo` on both the Vercel handler (`api/mcp.ts`) and the stdio entry (`src/stdio.ts`):
- **name**: `exa-search-server`
- **title**: `Exa` (display name shown in MCP clients)
- **version**: `3.2.1`
- **websiteUrl**: `https://exa.ai`
- **icons**: Exa favicon at `https://exa.ai/images/favicon-32x32.png`

Reported by a community member in Slack (`#connect`).

## Review & Testing Checklist for Human

- [ ] Deploy to preview/staging and connect via `npx @modelcontextprotocol/inspector` — verify the server name shows "Exa" (not "mcp-typescript server on vercel") and the icon renders
- [ ] Verify the icon URL `https://exa.ai/images/favicon-32x32.png` is stable and correct (it's the same one used in `<link rel="icon">` on exa.ai)

### Notes

The `mcp-handler` library's TypeScript type for `serverInfo` only declares `{ name, version }`, but at runtime it passes the full object through to `new McpServer(serverInfo, ...)` which accepts the complete MCP `Implementation` type (including `title`, `icons`, `websiteUrl`). Used `satisfies Implementation as { name: string; version: string }` to keep type safety while passing through the extra fields.

Link to Devin session: https://app.devin.ai/sessions/349522af53d84729839b29eef927b4eb
Requested by: @10ishq
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/exa-labs/exa-mcp-server/pull/341" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->