### PR TITLE
[mcp]: use client query param for source attribution

### DIFF
--- a/api/mcp.ts
+++ b/api/mcp.ts
@@ -378,6 +378,7 @@ async function getConfigFromRequest(request: Request): Promise<RequestConfig> {
   let authMethod: 'oauth' | 'api_key' | 'free_tier' = 'free_tier';
   let defaultSearchType: 'auto' | 'fast' | undefined;
   let invalidOAuthJwt = false;
+  let clientParam: string | null = null;
 
   // 1. Check x-api-key header (highest priority)
   const xApiKey = request.headers.get('x-api-key');
@@ -418,6 +419,7 @@ async function getConfigFromRequest(request: Request): Promise<RequestConfig> {
   try {
     const parsedUrl = new URL(request.url);
     const params = parsedUrl.searchParams;
+    clientParam = params.get('client');
 
     // 3. Check ?exaApiKey=YOUR_KEY (fallback for backwards compat, only if no header)
     if (!xApiKey && !getBearerToken(request) && params.has('exaApiKey')) {
@@ -467,7 +469,7 @@ async function getConfigFromRequest(request: Request): Promise<RequestConfig> {
       .filter(t => t.length > 0);
   }
 
-  const exaSource = request.headers.get('x-exa-source') || undefined;
+  const exaSource = request.headers.get('x-exa-source') || clientParam || undefined;
   const mcpSessionId = request.headers.get('MCP-Session-Id') || undefined;
 
   return { exaApiKey, enabledTools, debug, userProvidedApiKey, authMethod, exaSource, mcpSessionId, defaultSearchType, invalidOAuthJwt };

--- a/tests/unit/api/mcp.test.ts
+++ b/tests/unit/api/mcp.test.ts
@@ -193,6 +193,26 @@ describe("api/mcp handler", () => {
     });
   });
 
+  it("uses the client query parameter as the Exa source when the source header is absent", async () => {
+    const { config } = await callHandleRequest(
+      new Request("https://mcp.exa.ai/mcp?client=kiro-power", {
+        headers: {
+          "MCP-Session-Id": "session-123",
+          "User-Agent": "Kiro/1.0",
+        },
+      }),
+    );
+
+    expect(config).toMatchObject({
+      exaSource: "kiro-power",
+      mcpClient: {
+        source: "kiro-power",
+        sessionId: "session-123",
+        userAgent: "Kiro/1.0",
+      },
+    });
+  });
+
   it("falls back to unknown when initialize clientInfo cannot be extracted", async () => {
     const { config } = await callHandleRequest(
       new Request("https://mcp.exa.ai/mcp", {

--- a/tests/unit/tools/config.test.ts
+++ b/tests/unit/tools/config.test.ts
@@ -11,11 +11,11 @@ describe("integrationHeaders", () => {
   it("appends source and forwards MCP session id as an Exa reporting header when present", () => {
     expect(
       integrationHeaders("web-search-mcp", {
-        exaSource: "claude",
+        exaSource: "kiro-power",
         mcpSessionId: "session-123",
       }),
     ).toEqual({
-      "x-exa-integration": "web-search-mcp:claude",
+      "x-exa-integration": "web-search-mcp:kiro-power",
       "x-exa-mcp-session-id": "session-123",
     });
   });


### PR DESCRIPTION
## Summary
- Treat the hosted MCP `client` query parameter as `exaSource` when `x-exa-source` is absent.
- This lets URLs like `https://mcp.exa.ai/mcp?client=kiro-power` flow into downstream `x-exa-integration` values like `web-search-mcp:kiro-power` for analytics attribution.
- Added unit coverage for `?client=kiro-power` source propagation.

## Review & Testing Checklist for Human
- [ ] Verify the hosted MCP deployment uses this handler for `https://mcp.exa.ai/mcp?client=kiro-power`.
- [ ] After deploy, confirm a Kiro tool call writes `integration_header` with the `:kiro-power` suffix in `default.integration_fields`.

### Notes
- Local checks: `npm run ci` passed.
- Related dashboard PR: adds Kiro display/filtering in `github.com/exa-labs/monorepo`.

Link to Devin session: https://app.devin.ai/sessions/3314dfa1253d47c7a6ba8a99556aa372
Requested by: @tgonzalezc5