### PR TITLE
docs: remove API key from example URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,10 +306,11 @@ Use the npm package with your API key. [Get your API key](https://dashboard.exa.
 
 Enable additional tools with the `tools` parameter:
 
-```
-https://mcp.exa.ai/mcp?exaApiKey=YOUR_KEY&tools=web_search_exa,web_search_advanced_exa,web_fetch_exa
-```
+> **Note:** For security, it's recommended to pass your Exa API key via the `Authorization` header (`Authorization: Bearer YOUR_KEY`) or your client's dedicated secret management instead of a URL query parameter.
 
+```
+https://mcp.exa.ai/mcp?tools=web_search_exa,web_search_advanced_exa,web_fetch_exa
+```
 ## Agent Skills (Claude Skills)
 
 Ready-to-use skills for Claude Code. Each skill teaches Claude how to use Exa search for a specific task. Copy the content inside a dropdown and paste it into Claude Code — it handles the rest.


### PR DESCRIPTION
This PR removes the API key from the example URL in the README, as suggested in #334, to improve security by avoiding the exposure of secrets in query strings.