### PR TITLE
docs: use placeholder for api key in example url

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,10 +306,11 @@ Use the npm package with your API key. [Get your API key](https://dashboard.exa.
 
 Enable additional tools with the `tools` parameter:
 
-```
-https://mcp.exa.ai/mcp?exaApiKey=YOUR_KEY&tools=web_search_exa,web_search_advanced_exa,web_fetch_exa
-```
+> **Note:** For security, it's recommended to pass your Exa API key via the `Authorization` header (`Authorization: Bearer YOUR_KEY`) or your client's dedicated secret management instead of a URL query parameter.
 
+```
+https://mcp.exa.ai/mcp?tools=web_search_exa,web_search_advanced_exa,web_fetch_exa
+```
 ## Agent Skills (Claude Skills)
 
 Ready-to-use skills for Claude Code. Each skill teaches Claude how to use Exa search for a specific task. Copy the content inside a dropdown and paste it into Claude Code — it handles the rest.

--- a/README.md
+++ b/README.md
@@ -306,10 +306,10 @@ Use the npm package with your API key. [Get your API key](https://dashboard.exa.
 
 Enable additional tools with the `tools` parameter:
 
-> **Note:** For security, it's recommended to pass your Exa API key via the `Authorization` header (`Authorization: Bearer YOUR_KEY`) or your client's dedicated secret management instead of a URL query parameter.
+> **Note:** For security, it's recommended to pass your Exa API key via the `Authorization` header (`Authorization: Bearer YOUR_API_KEY`) or your client's dedicated secret management instead of a URL query parameter.
 
 ```
-https://mcp.exa.ai/mcp?tools=web_search_exa,web_search_advanced_exa,web_fetch_exa
+https://mcp.exa.ai/mcp?exaApiKey=YOUR_API_KEY&tools=web_search_exa,web_search_advanced_exa,web_fetch_exa
 ```
 ## Agent Skills (Claude Skills)
 

--- a/npm.readme.md
+++ b/npm.readme.md
@@ -239,7 +239,7 @@ Standard `mcpServers` format:
 Enable additional tools with the `tools` parameter:
 
 ```
-https://mcp.exa.ai/mcp?exaApiKey=YOUR_KEY&tools=web_search_exa,web_search_advanced_exa,web_fetch_exa
+https://mcp.exa.ai/mcp?exaApiKey=YOUR_API_KEY&tools=web_search_exa,web_search_advanced_exa,web_fetch_exa
 ```
 
 See the [full documentation](https://docs.exa.ai/reference/exa-mcp) for more details on tool configuration.


### PR DESCRIPTION
This PR replaces the hardcoded API key in the example URLs with a placeholder, and adds a note about securely passing the API key. This resolves #334.