### PR TITLE
fix(tools): correct openWorldHint to true for web-facing tools

### DIFF
--- a/src/tools/webFetch.ts
+++ b/src/tools/webFetch.ts
@@ -54,7 +54,7 @@ Returns: Clean text content and metadata from the page(s).`,
     {
       readOnlyHint: true,
       destructiveHint: false,
-      openWorldHint: false,
+      openWorldHint: true,
       idempotentHint: true
     },
     async ({ urls, maxCharacters }) => {

--- a/src/tools/webSearch.ts
+++ b/src/tools/webSearch.ts
@@ -36,7 +36,7 @@ export function registerWebSearchTool(server: McpServer, config?: WebSearchConfi
     {
       readOnlyHint: true,
       destructiveHint: false,
-      openWorldHint: false,
+      openWorldHint: true,
       idempotentHint: true
     },
     async ({ query, numResults }) => {

--- a/src/tools/webSearchAdvanced.ts
+++ b/src/tools/webSearchAdvanced.ts
@@ -62,7 +62,7 @@ Returns: Search results with optional highlights, summaries, and subpage content
     {
       readOnlyHint: true,
       destructiveHint: false,
-      openWorldHint: false,
+      openWorldHint: true,
       idempotentHint: true
     },
     async (params) => {


### PR DESCRIPTION
## Problem

`webSearch`, `webSearchAdvanced`, and `webFetch` all have `openWorldHint: false`, which is incorrect per the [MCP 2025-11-25 specification](https://modelcontextprotocol.io/specification/2025-11-25/schema#toolannotations):

> If true, this tool may interact with an "open world" of external entities. If false, the tool's domain of interaction is closed. **For example, the world of a web search tool is open, whereas that of a memory tool is not.**

All three tools query the live web (via Exa's API), so `openWorldHint: false` is a spec violation that misinforms MCP clients about the tools' reach.

Closes #348

## Solution

Set `openWorldHint: true` in the three affected tool registrations. Tools that already omit the annotation (`deepSearch`, `companyResearch`, etc.) are unaffected — their default behaviour is unchanged.

## Testing

No runtime changes — annotation values only affect MCP client hints, not tool execution.