### PR TITLE
feat: ENG-778 anonymous-auth A/B experiment (behind MCP_AB_ENABLED)

### DIFF
--- a/api/mcp.ts
+++ b/api/mcp.ts
@@ -1,6 +1,6 @@
 process.env.AGNOST_LOG_LEVEL = 'error';
 
-import { randomUUID } from 'node:crypto';
+import { createHash, randomUUID } from 'node:crypto';
 import { createMcpHandler } from 'mcp-handler';
 import type { Implementation } from '@modelcontextprotocol/sdk/types.js';
 import { initializeMcpServer } from '../src/mcp-handler.js';
@@ -167,11 +167,103 @@ function getClientIp(request: Request): string {
   return cfConnectingIp ?? xRealIp ?? xForwardedForFirst ?? 'unknown';
 }
 
-const RATE_LIMIT_ERROR_MESSAGE = `You've hit Exa's free MCP rate limit. To continue using without limits, create your own Exa API key.
+/**
+ * ENG-778 A/B test: optionally require auth for a deterministic slice of
+ * anonymous tool calls, to measure whether forcing signup actually increases the
+ * number of authenticated MCP users (rather than just driving people away).
+ *
+ * Assignment is a salted hash of the client IP, so a given client always lands in
+ * the same arm with zero added latency — no feature-flag network call in the hot
+ * path. Reporting happens out-of-band: exposure is counted in Redis (a per-arm,
+ * per-day HyperLogLog) and signups are attributed via utm tags on the dashboard
+ * URL surfaced in the gate/rate-limit message.
+ *
+ * Entirely gated behind MCP_AB_ENABLED; with it unset the server behaves exactly
+ * as before (everyone is "control"), so this is a no-op until explicitly ramped.
+ */
+interface ExperimentConfig {
+  enabled: boolean;
+  /** Percentage (0-100) of anonymous clients routed to the auth-required arm. */
+  treatmentPct: number;
+  /** Salt mixed into the IP hash; changing it reshuffles every client's arm. */
+  salt: string;
+}
 
-Fix: Create API key at https://dashboard.exa.ai/api-keys , then either:
+type ExperimentArm = 'control' | 'treatment';
+
+/** Campaign id stamped on experiment signups so they can be joined back per arm. */
+const EXPERIMENT_CAMPAIGN = 'eng778';
+
+/** TTL on the per-day exposure HyperLogLog keys (kept long enough to read out). */
+const EXPERIMENT_EXPOSURE_TTL_SECONDS = 30 * 24 * 60 * 60;
+
+function getExperimentConfig(): ExperimentConfig {
+  const parsedPct = Number.parseInt(process.env.MCP_AB_TREATMENT_PCT ?? '0', 10);
+  const treatmentPct = Number.isFinite(parsedPct) ? Math.min(100, Math.max(0, parsedPct)) : 0;
+  return {
+    enabled: process.env.MCP_AB_ENABLED === 'true',
+    treatmentPct,
+    salt: process.env.MCP_AB_SALT || EXPERIMENT_CAMPAIGN,
+  };
+}
+
+/**
+ * Deterministically bucket a client into an experiment arm from a salted hash of
+ * its IP. Stable across requests for the same (salt, ip).
+ */
+function assignExperimentArm(ip: string, config: ExperimentConfig): ExperimentArm {
+  const bucket = createHash('sha256').update(`${config.salt}:${ip}`).digest().readUInt16BE(0) % 100;
+  return bucket < config.treatmentPct ? 'treatment' : 'control';
+}
+
+/** Dashboard signup URL tagged so the resulting signup is attributable to its arm. */
+function experimentSignupUrl(arm: ExperimentArm): string {
+  const params = new URLSearchParams({
+    utm_source: 'mcp',
+    utm_medium: 'mcp_server',
+    utm_campaign: EXPERIMENT_CAMPAIGN,
+    utm_content: `arm_${arm}`,
+  });
+  return `https://dashboard.exa.ai/api-keys?${params.toString()}`;
+}
+
+/**
+ * Record an anonymous client's experiment exposure for offline analysis, using a
+ * per-arm, per-day HyperLogLog so unique exposed clients per arm can be read back
+ * cheaply. Best-effort: never blocks or fails the request.
+ */
+async function recordExperimentExposure(arm: ExperimentArm, ip: string, debug: boolean): Promise<void> {
+  initializeRateLimiters();
+
+  if (!redisClient) {
+    return;
+  }
+
+  try {
+    const day = new Date().toISOString().slice(0, 10);
+    const key = `exa-mcp:ab:${EXPERIMENT_CAMPAIGN}:${arm}:${day}`;
+    await redisClient.pfadd(key, ip);
+    await redisClient.expire(key, EXPERIMENT_EXPOSURE_TTL_SECONDS);
+  } catch (error) {
+    if (debug) {
+      console.error('[EXA-MCP] Failed to record experiment exposure:', error);
+    }
+  }
+}
+
+/**
+ * Build the free-tier rate-limit error message. When the request is part of the
+ * ENG-778 experiment, the signup URL is tagged with the client's arm so the
+ * resulting signup can be attributed back to it.
+ */
+function buildRateLimitMessage(experimentArm?: ExperimentArm): string {
+  const signupUrl = experimentArm ? experimentSignupUrl(experimentArm) : 'https://dashboard.exa.ai/api-keys';
+  return `You've hit Exa's free MCP rate limit. To continue using without limits, create your own Exa API key.
+
+Fix: Create API key at ${signupUrl} , then either:
 - Set the header: Authorization: Bearer YOUR_EXA_API_KEY
 - Or use the URL: https://mcp.exa.ai/mcp?exaApiKey=YOUR_EXA_API_KEY`;
+}
 
 /**
  * Create a JSON-RPC 2.0 error response for rate limiting.
@@ -179,13 +271,13 @@ Fix: Create API key at https://dashboard.exa.ai/api-keys , then either:
  * Note: We intentionally hide rate limit dimension info (limit set to 0) to prevent
  * users from inferring which limit they hit (QPS vs daily).
  */
-function createRateLimitResponse(retryAfterSeconds: number, reset: number): Response {
+function createRateLimitResponse(retryAfterSeconds: number, reset: number, experimentArm?: ExperimentArm): Response {
   return new Response(
     JSON.stringify({
       jsonrpc: '2.0',
       error: {
         code: -32000,
-        message: RATE_LIMIT_ERROR_MESSAGE,
+        message: buildRateLimitMessage(experimentArm),
       },
       id: null,
     }),
@@ -270,7 +362,7 @@ async function saveBypassRequestInfo(ip: string, userAgent: string, debug: boole
  * Check rate limits for a given IP.
  * Returns null if within limits, or a Response if rate limited.
  */
-async function checkRateLimits(ip: string, debug: boolean): Promise<Response | null> {
+async function checkRateLimits(ip: string, debug: boolean, experimentArm?: ExperimentArm): Promise<Response | null> {
   if (!qpsLimiter || !dailyLimiter) {
     return null; // Rate limiting not configured
   }
@@ -283,7 +375,7 @@ async function checkRateLimits(ip: string, debug: boolean): Promise<Response | n
         console.log(`[EXA-MCP] QPS rate limit exceeded for IP: ${ip}`);
       }
       const retryAfter = Math.ceil((qpsResult.reset - Date.now()) / 1000);
-      return createRateLimitResponse(retryAfter, qpsResult.reset);
+      return createRateLimitResponse(retryAfter, qpsResult.reset, experimentArm);
     }
     
     // Check daily limit
@@ -293,7 +385,7 @@ async function checkRateLimits(ip: string, debug: boolean): Promise<Response | n
         console.log(`[EXA-MCP] Daily rate limit exceeded for IP: ${ip}`);
       }
       const retryAfter = Math.ceil((dailyResult.reset - Date.now()) / 1000);
-      return createRateLimitResponse(retryAfter, dailyResult.reset);
+      return createRateLimitResponse(retryAfter, dailyResult.reset, experimentArm);
     }
     
     return null; // Within limits
@@ -522,7 +614,10 @@ function hasAuth(request: Request): boolean {
  */
 const PROTECTED_RESOURCE_METADATA_URL = 'https://mcp.exa.ai/.well-known/oauth-protected-resource/mcp';
 
-function create401Response(reason: 'missing' | 'invalid_token' = 'missing'): Response {
+function create401Response(
+  reason: 'missing' | 'invalid_token' = 'missing',
+  options?: { experimentArm?: ExperimentArm },
+): Response {
   const params: string[] = [];
   if (reason === 'invalid_token') {
     params.push('error="invalid_token"');
@@ -530,10 +625,17 @@ function create401Response(reason: 'missing' | 'invalid_token' = 'missing'): Res
   }
   params.push(`resource_metadata="${PROTECTED_RESOURCE_METADATA_URL}"`);
 
-  const message =
+  let message =
     reason === 'invalid_token'
       ? 'The access token is invalid or expired. Refresh or re-authenticate.'
       : 'Authentication required. Use OAuth or provide an API key.';
+
+  // When gated as part of the experiment, surface a tagged dashboard URL so a
+  // client that shows the error to a human gives them a one-click path to sign
+  // up — and so that signup is attributable to the treatment arm.
+  if (options?.experimentArm) {
+    message = `Authentication required to use the Exa MCP server. Create a free Exa API key at ${experimentSignupUrl(options.experimentArm)} and pass it as 'Authorization: Bearer YOUR_EXA_API_KEY', or authenticate via OAuth.`;
+  }
 
   return new Response(
     JSON.stringify({
@@ -615,6 +717,27 @@ async function processRequest(request: Request, options?: { forceOAuth?: boolean
     return create401Response('invalid_token');
   }
 
+  // ENG-778 experiment: deterministically assign anonymous tool calls to an arm.
+  // The treatment arm is gated behind auth (401); both arms are recorded so we
+  // can read unique exposed clients per arm. No-op unless MCP_AB_ENABLED=true.
+  let experimentArm: ExperimentArm | undefined;
+  const experimentConfig = getExperimentConfig();
+  if (
+    experimentConfig.enabled &&
+    request.method === 'POST' &&
+    !config.userProvidedApiKey &&
+    !bypassRateLimit &&
+    !requireOAuth &&
+    isRateLimitedMethod(body ?? '')
+  ) {
+    const clientIp = getClientIp(request);
+    experimentArm = assignExperimentArm(clientIp, experimentConfig);
+    await recordExperimentExposure(experimentArm, clientIp, config.debug);
+    if (experimentArm === 'treatment') {
+      return create401Response('missing', { experimentArm });
+    }
+  }
+
   const storedMcpClient = isInitializeRequest ? undefined : await loadMcpClientMetadata(config.mcpSessionId, config.debug);
   config.mcpClient = buildMcpClientMetadata({
     source: config.exaSource,
@@ -653,7 +776,7 @@ async function processRequest(request: Request, options?: { forceOAuth?: boolean
         console.log(`[EXA-MCP] Client IP: ${clientIp}, method: tools/call`);
       }
       
-      const rateLimitResponse = await checkRateLimits(clientIp, config.debug);
+      const rateLimitResponse = await checkRateLimits(clientIp, config.debug, experimentArm);
       if (rateLimitResponse) {
         return rateLimitResponse;
       }

--- a/tests/unit/api/mcp.test.ts
+++ b/tests/unit/api/mcp.test.ts
@@ -7,6 +7,7 @@ const {
   isJwtTokenMock,
   rateLimitInstances,
   redisValues,
+  pfaddKeys,
   RatelimitMock,
   RedisMock,
   verifyOAuthTokenMock,
@@ -23,6 +24,7 @@ const {
   const isJwtTokenMock = vi.fn((token: string) => token === "jwt-token" || token === "invalid-jwt");
   const rateLimitInstances: Array<{ limit: ReturnType<typeof vi.fn> }> = [];
   const redisValues = new Map<string, string>();
+  const pfaddKeys: string[] = [];
   class RatelimitMock {
     static slidingWindow = vi.fn((limit: number, window: string) => ({ limit, window, type: "sliding" }));
     static fixedWindow = vi.fn((limit: number, window: string) => ({ limit, window, type: "fixed" }));
@@ -34,6 +36,10 @@ const {
   class RedisMock {
     zadd = vi.fn();
     expire = vi.fn();
+    pfadd = vi.fn(async (key: string) => {
+      pfaddKeys.push(key);
+      return 1;
+    });
     set = vi.fn(async (key: string, value: string) => {
       redisValues.set(key, value);
       return "OK";
@@ -49,6 +55,7 @@ const {
     isJwtTokenMock,
     rateLimitInstances,
     redisValues,
+    pfaddKeys,
     RatelimitMock,
     RedisMock,
     verifyOAuthTokenMock,
@@ -108,6 +115,7 @@ describe("api/mcp handler", () => {
     capturedRequests.length = 0;
     rateLimitInstances.length = 0;
     redisValues.clear();
+    pfaddKeys.length = 0;
     isJwtTokenMock.mockImplementation((token: string) => token === "jwt-token" || token === "invalid-jwt");
     verifyOAuthTokenMock.mockResolvedValue(null);
     vi.spyOn(console, "log").mockImplementation(() => undefined);
@@ -123,6 +131,103 @@ describe("api/mcp handler", () => {
     delete process.env.RATE_LIMIT_BYPASS;
     delete process.env.UPSTASH_REDIS_REST_TOKEN;
     delete process.env.UPSTASH_REDIS_REST_URL;
+    delete process.env.MCP_AB_ENABLED;
+    delete process.env.MCP_AB_TREATMENT_PCT;
+    delete process.env.MCP_AB_SALT;
+  });
+
+  function toolCallRequest() {
+    return new Request("https://mcp.exa.ai/mcp", {
+      method: "POST",
+      headers: { "Content-Type": "application/json", "x-real-ip": "203.0.113.7" },
+      body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "tools/call" }),
+    });
+  }
+
+  describe("ENG-778 auth experiment", () => {
+    it("is a no-op for anonymous tool calls when MCP_AB_ENABLED is unset", async () => {
+      process.env.EXA_API_KEY = "env-key";
+
+      const { response } = await callHandleRequest(toolCallRequest());
+
+      expect(response.status).toBe(200);
+      expect(createMcpHandlerMock).toHaveBeenCalled();
+      expect(pfaddKeys).toHaveLength(0);
+    });
+
+    it("gates treatment-arm anonymous tool calls with a tagged 401 and records exposure", async () => {
+      process.env.EXA_API_KEY = "env-key";
+      process.env.MCP_AB_ENABLED = "true";
+      process.env.MCP_AB_TREATMENT_PCT = "100";
+      process.env.KV_REST_API_URL = "https://redis.example";
+      process.env.KV_REST_API_TOKEN = "redis-token";
+
+      const { response } = await callHandleRequest(toolCallRequest());
+
+      expect(response.status).toBe(401);
+      expect(createMcpHandlerMock).not.toHaveBeenCalled();
+      expect(response.headers.get("WWW-Authenticate")).toContain(
+        'resource_metadata="https://mcp.exa.ai/.well-known/oauth-protected-resource/mcp"',
+      );
+      const payload = (await response.json()) as { error: { message: string } };
+      expect(payload.error.message).toContain("utm_campaign=eng778");
+      expect(payload.error.message).toContain("utm_content=arm_treatment");
+      expect(pfaddKeys).toContain("exa-mcp:ab:eng778:treatment:" + new Date().toISOString().slice(0, 10));
+    });
+
+    it("lets control-arm anonymous tool calls through and records exposure", async () => {
+      process.env.EXA_API_KEY = "env-key";
+      process.env.MCP_AB_ENABLED = "true";
+      process.env.MCP_AB_TREATMENT_PCT = "0";
+      process.env.KV_REST_API_URL = "https://redis.example";
+      process.env.KV_REST_API_TOKEN = "redis-token";
+
+      const { response } = await callHandleRequest(toolCallRequest());
+
+      expect(response.status).toBe(200);
+      expect(createMcpHandlerMock).toHaveBeenCalled();
+      expect(pfaddKeys).toContain("exa-mcp:ab:eng778:control:" + new Date().toISOString().slice(0, 10));
+    });
+
+    it("never gates a client that provides its own API key", async () => {
+      process.env.MCP_AB_ENABLED = "true";
+      process.env.MCP_AB_TREATMENT_PCT = "100";
+
+      const { response } = await callHandleRequest(
+        new Request("https://mcp.exa.ai/mcp", {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            "x-real-ip": "203.0.113.7",
+            "x-api-key": "user-key",
+          },
+          body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "tools/call" }),
+        }),
+      );
+
+      expect(response.status).toBe(200);
+      expect(createMcpHandlerMock).toHaveBeenCalled();
+      expect(pfaddKeys).toHaveLength(0);
+    });
+
+    it("tags the rate-limit nudge with the control arm", async () => {
+      process.env.EXA_API_KEY = "env-key";
+      process.env.MCP_AB_ENABLED = "true";
+      process.env.MCP_AB_TREATMENT_PCT = "0";
+      process.env.KV_REST_API_URL = "https://redis.example";
+      process.env.KV_REST_API_TOKEN = "redis-token";
+      const reset = Date.now() + 10_000;
+      rateLimitInstances.push(
+        { limit: vi.fn().mockResolvedValue({ success: false, reset }) },
+        { limit: vi.fn().mockResolvedValue({ success: true, reset }) },
+      );
+
+      const { response } = await callHandleRequest(toolCallRequest());
+
+      expect(response.status).toBe(429);
+      const payload = (await response.json()) as { error: { message: string } };
+      expect(payload.error.message).toContain("utm_content=arm_control");
+    });
   });
 
   it("falls back to EXA_API_KEY without marking it as user-provided", async () => {


### PR DESCRIPTION
## Summary
Adds the minimal machinery to A/B test **requiring auth** for anonymous MCP tool calls vs. the current no-auth default, to measure whether forcing signup actually increases the number of *authenticated* MCP users (ENG-778). Entirely gated behind `MCP_AB_ENABLED` — with the flag unset the server behaves exactly as today (everyone is "control"), so this is a no-op until explicitly ramped.

All changes are in `api/mcp.ts` (+ tests). New env flags:
- `MCP_AB_ENABLED` (default `false` → full no-op)
- `MCP_AB_TREATMENT_PCT` (0–100, share of anonymous clients routed to the auth-required arm)
- `MCP_AB_SALT` (mixed into the IP hash; changing it reshuffles every client's arm)

**Assignment is done in-process** (no feature-flag network call in the hot path): for anonymous POST `tools/call` that isn't already bypassed/plugin/forced-OAuth,
```
arm = sha256(`${salt}:${clientIp}`) % 100 < treatmentPct ? 'treatment' : 'control'
```
- `treatment` → `create401Response('missing', { experimentArm })` — same `WWW-Authenticate` OAuth challenge as today, plus a **utm-tagged dashboard signup URL** in the JSON-RPC error message (`utm_campaign=eng778`, `utm_content=arm_treatment`).
- `control` → unchanged; its existing rate-limit nudge URL is tagged `arm_control` so both arms share the same measurement instrument.

**Reporting is out of band** (no analytics dep added to the server):
- Exposure denominator: per-arm/day Redis HyperLogLog `exa-mcp:ab:eng778:{arm}:{date}` via the Upstash client already in the request path (best-effort; never blocks a request).
- Auth numerator: the utm tags ride the existing `posthog_landing_signup_bridge` (the auth/dashboard apps already call `extractUtmParams` at sign-in), so no new table/pipeline.

Why the gate funnels to the tagged dashboard URL rather than relying on raw OAuth: the MCP client owns the OAuth `state` and builds the authorize request from discovery docs, so per-client attribution through pure OAuth isn't clean — the tagged URL is.

## Testing
`npm run ci` (typecheck + 92 vitest tests, incl. 5 new) green; `tsc --noEmit` under both the default and test tsconfigs is clean. New tests cover: no-op when flag unset, treatment 401 + tagged message + exposure recorded, control pass-through + exposure recorded, never gating a client with its own key, and the control-tagged rate-limit nudge.

## Rollout
1. Deploy with `MCP_AB_ENABLED=false` (no-op).
2. One manual tagged signup → confirm the row lands in `posthog_landing_signup_bridge` with `utm_campaign=eng778`.
3. Ramp `MCP_AB_TREATMENT_PCT` 10 → 50; read auths/exposed-client per arm + the tool-call volume guardrail.
4. Kill switch = set `MCP_AB_ENABLED=false`.

Draft — pending sign-off on metric weighting and arm split before enabling.

Link to Devin session: https://app.devin.ai/sessions/9d2532251e464e8693221bc1b58c1395
Requested by: @liinnh