### PR TITLE
Add instant as option for defaultSearchType

### DIFF
--- a/api/mcp.ts
+++ b/api/mcp.ts
@@ -361,7 +361,7 @@ interface RequestConfig {
   exaSource?: string;
   mcpSessionId?: string;
   mcpClient?: McpClientMetadata;
-  defaultSearchType?: 'auto' | 'fast';
+  defaultSearchType?: 'auto' | 'fast' | 'instant';
   /** True when a Bearer token was a JWT but failed OAuth verification (expired, bad sig, wrong issuer/audience). */
   invalidOAuthJwt: boolean;
 }
@@ -376,7 +376,7 @@ async function getConfigFromRequest(request: Request): Promise<RequestConfig> {
   let debug = process.env.DEBUG === 'true';
   let userProvidedApiKey = false;
   let authMethod: 'oauth' | 'api_key' | 'free_tier' = 'free_tier';
-  let defaultSearchType: 'auto' | 'fast' | undefined;
+  let defaultSearchType: 'auto' | 'fast' | 'instant' | undefined;
   let invalidOAuthJwt = false;
 
   // 1. Check x-api-key header (highest priority)
@@ -445,10 +445,10 @@ async function getConfigFromRequest(request: Request): Promise<RequestConfig> {
       debug = params.get('debug') === 'true';
     }
 
-    // Support ?defaultSearchType=auto|fast
+    // Support ?defaultSearchType
     if (params.has('defaultSearchType')) {
       const dst = params.get('defaultSearchType');
-      if (dst === 'auto' || dst === 'fast') {
+      if (dst === 'auto' || dst === 'fast' || dst === 'instant') {
         defaultSearchType = dst;
       }
     }
@@ -467,6 +467,13 @@ async function getConfigFromRequest(request: Request): Promise<RequestConfig> {
       .filter(t => t.length > 0);
   }
 
+  if (!defaultSearchType && process.env.DEFAULT_SEARCH_TYPE) {
+    const dst = process.env.DEFAULT_SEARCH_TYPE;
+    if (dst === 'auto' || dst === 'fast' || dst === 'instant') {
+      defaultSearchType = dst;
+    }
+  }
+
   const exaSource = request.headers.get('x-exa-source') || undefined;
   const mcpSessionId = request.headers.get('MCP-Session-Id') || undefined;
 
@@ -479,7 +486,7 @@ async function getConfigFromRequest(request: Request): Promise<RequestConfig> {
  * configuration (tools and API key). This prevents API key leakage between
  * different users who might pass different keys via URL.
  */
-function createHandler(config: { exaApiKey?: string; enabledTools?: string[]; debug: boolean; userProvidedApiKey: boolean; exaSource?: string; mcpSessionId?: string; mcpClient?: McpClientMetadata; defaultSearchType?: 'auto' | 'fast' }) {
+function createHandler(config: { exaApiKey?: string; enabledTools?: string[]; debug: boolean; userProvidedApiKey: boolean; exaSource?: string; mcpSessionId?: string; mcpClient?: McpClientMetadata; defaultSearchType?: 'auto' | 'fast' | 'instant' }) {
   return createMcpHandler(
     (server: any) => {
       initializeMcpServer(server, config);

--- a/src/mcp-handler.ts
+++ b/src/mcp-handler.ts
@@ -37,7 +37,7 @@ export interface McpConfig {
   exaSource?: string;
   mcpSessionId?: string;
   mcpClient?: unknown;
-  defaultSearchType?: 'auto' | 'fast';
+  defaultSearchType?: 'auto' | 'fast' | 'instant';
 }
 
 /**

--- a/src/stdio.ts
+++ b/src/stdio.ts
@@ -17,8 +17,8 @@ function parseTools(value: string | undefined): string[] | undefined {
   return tools.length > 0 ? tools : undefined;
 }
 
-function parseSearchType(value: string | undefined): "auto" | "fast" | undefined {
-  if (value === "auto" || value === "fast") return value;
+function parseSearchType(value: string | undefined): "auto" | "fast" | "instant" | undefined {
+  if (value === "auto" || value === "fast" || value === "instant") return value;
   return undefined;
 }
 

--- a/src/tools/webSearch.ts
+++ b/src/tools/webSearch.ts
@@ -12,7 +12,7 @@ import { checkpoint } from "agnost"
 type WebSearchConfig = {
   exaApiKey?: string;
   userProvidedApiKey?: boolean;
-  defaultSearchType?: 'auto' | 'fast';
+  defaultSearchType?: 'auto' | 'fast' | 'instant';
   exaSource?: string;
   mcpSessionId?: string;
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,7 +1,7 @@
 // Exa API Types
 export interface ExaSearchRequest {
   query: string;
-  type: 'auto' | 'fast' | 'deep' | 'deep-reasoning';
+  type: 'auto' | 'fast' | 'instant' | 'deep' | 'deep-reasoning';
   category?: 'company' | 'research paper' | 'news' | 'pdf' | 'github' | 'personal site' | 'people' | 'financial report';
   includeDomains?: string[];
   excludeDomains?: string[];

--- a/tests/unit/api/mcp.test.ts
+++ b/tests/unit/api/mcp.test.ts
@@ -114,6 +114,7 @@ describe("api/mcp handler", () => {
     vi.spyOn(console, "error").mockImplementation(() => undefined);
 
     delete process.env.DEBUG;
+    delete process.env.DEFAULT_SEARCH_TYPE;
     delete process.env.ENABLED_TOOLS;
     delete process.env.EXA_API_KEY;
     delete process.env.EXA_API_KEY_BYPASS;
@@ -427,6 +428,26 @@ describe("api/mcp handler", () => {
       authMethod: "api_key",
     });
     expect(new URL(forwardedRequest?.url ?? "").searchParams.has("exaApiKey")).toBe(false);
+  });
+
+  it("accepts instant as a defaultSearchType query parameter", async () => {
+    const { config } = await callHandleRequest(
+      new Request("https://mcp.exa.ai/mcp?defaultSearchType=instant"),
+    );
+
+    expect(config).toMatchObject({
+      defaultSearchType: "instant",
+    });
+  });
+
+  it("falls back to DEFAULT_SEARCH_TYPE from the environment", async () => {
+    process.env.DEFAULT_SEARCH_TYPE = "instant";
+
+    const { config } = await callHandleRequest(new Request("https://mcp.exa.ai/mcp"));
+
+    expect(config).toMatchObject({
+      defaultSearchType: "instant",
+    });
   });
 
   it("requires auth before initializing MCP when OAuth is forced", async () => {

--- a/tests/unit/stdio.test.ts
+++ b/tests/unit/stdio.test.ts
@@ -86,6 +86,16 @@ describe("Stdio entrypoint", () => {
     });
   });
 
+  it("buildConfigFromEnv accepts instant as a default search type", async () => {
+    const { buildConfigFromEnv } = await import("../../src/stdio.js");
+
+    const config = buildConfigFromEnv({
+      DEFAULT_SEARCH_TYPE: "instant",
+    });
+
+    expect(config.defaultSearchType).toBe("instant");
+  });
+
   it("main() wires the McpServer through stdio transport with env-derived config", async () => {
     const { main } = await import("../../src/stdio.js");
 

--- a/tests/unit/tools/webSearch.test.ts
+++ b/tests/unit/tools/webSearch.test.ts
@@ -79,6 +79,30 @@ describe("registerWebSearchTool", () => {
     expect((result as any).content[0].text).toContain("First highlight");
   });
 
+  it("uses an instant default search type when configured", async () => {
+    const { registerWebSearchTool } = await import("../../../src/tools/webSearch.js");
+    const server = new FakeMcpServer();
+    requestMock.mockResolvedValue(searchResponse);
+
+    registerWebSearchTool(server as any, {
+      defaultSearchType: "instant",
+    });
+
+    await server.getTool("web_search_exa").handler({
+      query: "AI breakthroughs",
+    });
+
+    expect(requestMock).toHaveBeenCalledWith(
+      "/search",
+      "POST",
+      expect.objectContaining({
+        type: "instant",
+      }),
+      undefined,
+      expect.any(Object),
+    );
+  });
+
   it("returns a friendly message when Exa has no results", async () => {
     const { registerWebSearchTool } = await import("../../../src/tools/webSearch.js");
     const server = new FakeMcpServer();


### PR DESCRIPTION
## Summary

Adds support for `instant` as a configured default search type for `web_search_exa`.

This lets clients pass `?defaultSearchType=instant` on the HTTP MCP endpoint or `DEFAULT_SEARCH_TYPE=instant` for stdio/local MCP, and have the server forward `type: "instant"` in the normal `web_search_exa` Exa request.

## Behavior

- Existing default behavior remains unchanged: unset/default still falls back to `auto`.
- Existing `auto` and `fast` values continue to work.
- Other invalid values are still ignored.
- The MCP tool input schema is unchanged; this does not add a per-call `type` argument to `web_search_exa`.

## Validation

- `npm test -- tests/unit/stdio.test.ts tests/unit/tools/webSearch.test.ts tests/unit/api/mcp.test.ts`
- `npm run typecheck`
