### PR TITLE
Add MIT license metadata to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "people"
   ],
   "author": "Exa Labs",
+  "license": "MIT",
   "scripts": {
     "build": "npm run build:stdio",
     "build:stdio": "esbuild src/stdio-cli.ts --bundle --platform=node --target=node20 --format=cjs --outfile=dist/stdio.cjs --banner:js=\"#!/usr/bin/env node\" && chmod +x dist/stdio.cjs",


### PR DESCRIPTION
# Add MIT license metadata to package.json

## Summary

- Add `"license": "MIT"` to `package.json`.

## Why

The repository is MIT licensed and ships a `LICENSE` file, but the published npm package metadata does not include a `license` field. Adding it makes the npm metadata match the repository license and helps package consumers and automated compliance tooling.

## Verification

- `node -e "const p=require('./package.json'); if(p.license!=='MIT') process.exit(1); console.log(JSON.stringify({name:p.name,version:p.version,license:p.license}))"`
- `npm pack --dry-run --ignore-scripts --json`
- `git diff --check`

Note: `git diff --check` passed with a CRLF warning only.
