### PR TITLE
Add badge for mcp-customs to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Exa MCP Server
-
+[![mcp-customs](https://img.shields.io/badge/mcp--customs-CLEARED_97%2F100-brightgreen)](https://github.com/mcpcustoms/mcp-customs)
 [![Install in Cursor](https://img.shields.io/badge/Install_in-Cursor-000000?style=flat-square&logoColor=white)](https://cursor.com/en/install-mcp?name=exa&config=eyJuYW1lIjoiZXhhIiwidHlwZSI6Imh0dHAiLCJ1cmwiOiJodHRwczovL21jcC5leGEuYWkvbWNwIn0=)
 [![Install in VS Code](https://img.shields.io/badge/Install_in-VS_Code-0098FF?style=flat-square&logo=visualstudiocode&logoColor=white)](https://vscode.dev/redirect/mcp/install?name=exa&config=%7B%22type%22%3A%22http%22%2C%22url%22%3A%22https%3A%2F%2Fmcp.exa.ai%2Fmcp%22%7D)
 [![npm version](https://badge.fury.io/js/exa-mcp-server.svg)](https://www.npmjs.com/package/exa-mcp-server)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Exa MCP Server
-[![mcp-customs](https://img.shields.io/badge/mcp--customs-CLEARED_97%2F100-brightgreen)](https://github.com/mcpcustoms/mcp-customs)
+[![mcp-customs](https://img.shields.io/badge/mcp--customs-CLEARED_97%2F100-brightgreen)](https://mcpcustoms.github.io/?server=exa-mcp-server)
 [![Install in Cursor](https://img.shields.io/badge/Install_in-Cursor-000000?style=flat-square&logoColor=white)](https://cursor.com/en/install-mcp?name=exa&config=eyJuYW1lIjoiZXhhIiwidHlwZSI6Imh0dHAiLCJ1cmwiOiJodHRwczovL21jcC5leGEuYWkvbWNwIn0=)
 [![Install in VS Code](https://img.shields.io/badge/Install_in-VS_Code-0098FF?style=flat-square&logo=visualstudiocode&logoColor=white)](https://vscode.dev/redirect/mcp/install?name=exa&config=%7B%22type%22%3A%22http%22%2C%22url%22%3A%22https%3A%2F%2Fmcp.exa.ai%2Fmcp%22%7D)
 [![npm version](https://badge.fury.io/js/exa-mcp-server.svg)](https://www.npmjs.com/package/exa-mcp-server)


### PR DESCRIPTION
Ran your server through mcp-customs (https://github.com/mcpcustoms/mcp-customs), a free offline scanner I built that checks MCP servers for common security risks before install. It came back clean — 97/100.

Wrote up the full methodology (and where the tool got things wrong on other servers) here: https://dev.to/mcpcustoms/we-scanned-12-popular-mcp-servers-the-most-interesting-finding-was-our-own-false-positives-kcf

Adding the badge is obviously optional — totally fine to close this if you'd rather not, no hard feelings either way.