### PR TITLE
fix(web_fetch_exa): honor maxCharacters by sending correct /contents payload

### DIFF
--- a/src/tools/webFetch.ts
+++ b/src/tools/webFetch.ts
@@ -67,11 +67,9 @@ Returns: Clean text content and metadata from the page(s).`,
         const exa = new Exa(config?.exaApiKey || process.env.EXA_API_KEY || '');
 
         const crawlRequest = {
-          ids: urls,
-          contents: {
-            text: {
-              maxCharacters: maxCharacters || API_CONFIG.DEFAULT_MAX_CHARACTERS
-            },
+          urls,
+          text: {
+            maxCharacters: maxCharacters || API_CONFIG.DEFAULT_MAX_CHARACTERS
           },
         };
 

--- a/tests/unit/tools/webFetch.test.ts
+++ b/tests/unit/tools/webFetch.test.ts
@@ -52,11 +52,9 @@ describe("registerWebFetchTool", () => {
       "/contents",
       "POST",
       {
-        ids: ["https://example.com/page", "https://example.com/missing"],
-        contents: {
-          text: {
-            maxCharacters: 500,
-          },
+        urls: ["https://example.com/page", "https://example.com/missing"],
+        text: {
+          maxCharacters: 500,
         },
       },
       undefined,


### PR DESCRIPTION
## What's broken

`web_fetch_exa` builds the `/contents` POST body as:

```json
{ "ids": ["..."], "contents": { "text": { "maxCharacters": 3000 } } }
```

The Exa `/contents` endpoint expects `urls` and `text` at the **top level**:

```json
{ "urls": ["..."], "text": { "maxCharacters": 3000 } }
```

Because the `contents` wrapper is unrecognized, `text` (and therefore `maxCharacters`) is dropped — the cap is silently ignored and every fetch returns the full page regardless of `maxCharacters`. (`ids` is tolerated as a legacy alias for `urls`, so content still returns, which masked the bug.)

## Fix

Send the documented shape `{ urls, text: { maxCharacters } }`, matching exa-js `getContents()` (`{ urls, ...ContentsOptions }`).

## Evidence

Live A/B against `api.exa.ai/contents` with `maxCharacters: 100`:

| Payload | Returned text |
|---|---|
| `{ ids, contents: { text } }` (before) | 26,059 chars — cap ignored |
| `{ urls, text }` (after) | 100 chars — cap honored |

## Tests

- Updated the unit test that asserted the old payload shape.
- `npm run typecheck` clean; `npm run test` → 91/91 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/exa-labs/exa-mcp-server/pull/365" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->