### PR TITLE
Add Exa Agent support to MCP

### DIFF
--- a/.vercelignore
+++ b/.vercelignore
@@ -10,6 +10,7 @@ build/
 # Documentation
 *.md
 !README.md
+!skills/**
 
 # Git
 .git/

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,7 @@ WORKDIR /app
 
 # Copy compiled code from the builder stage
 COPY --from=builder /app/dist ./dist
+COPY skills/ ./skills/
 COPY package.json package-lock.json ./
 
 # Install only production dependencies

--- a/README.md
+++ b/README.md
@@ -347,7 +347,7 @@ https://mcp.exa.ai/mcp?tools=agent_tools
 If you want both search and Exa Agent tools enabled:
 
 ```
-https://mcp.exa.ai/mcp?tools=web_search_exa,agent_tools
+https://mcp.exa.ai/mcp?tools=web_search_exa,web_fetch_exa,agent_tools
 ```
 
 ## Agent Skills (Claude Skills)

--- a/README.md
+++ b/README.md
@@ -338,10 +338,16 @@ Enable additional tools with the `tools` parameter:
 https://mcp.exa.ai/mcp?exaApiKey=YOUR_KEY&tools=web_search_exa,web_search_advanced_exa,web_fetch_exa
 ```
 
-If you want to use Exa Agent, enable all tools like so:
+If you want to use Exa Agent, enable the optional toolset like so:
 
 ```
-https://mcp.exa.ai/mcp?exaApiKey=YOUR_KEY&tools=agent_create_run,agent_wait_for_run,agent_get_run_output,agent_cancel_run
+https://mcp.exa.ai/mcp?tools=agent_tools
+```
+
+If you want both search and Exa Agent tools enabled:
+
+```
+https://mcp.exa.ai/mcp?tools=web_search_exa,agent_tools
 ```
 
 ## Agent Skills (Claude Skills)

--- a/README.md
+++ b/README.md
@@ -311,6 +311,14 @@ Use the npm package with your API key. [Get your API key](https://dashboard.exa.
 | ---- | ----------- |
 | `web_search_advanced_exa` | Advanced web search with full control over filters, domains, dates, and content options |
 
+**[Exa Agent](https://exa.ai/docs/reference/agent-api-guide) Tools** (optional, OAuth or API key required):
+| Tool | Description |
+| ---- | ----------- |
+| `agent_create_run` | Start an async Exa Agent run for multi-step research, list-building, enrichment, or structured output |
+| `agent_wait_for_run` | Poll an Agent run until terminal status or timeout |
+| `agent_get_run_output` | Retrieve completed text, structured output, grounding, usage, and cost |
+| `agent_cancel_run` | Cancel a queued or running Agent run |
+
 **Deprecated** (still available for backwards compatibility):
 
 | Tool | Use instead |
@@ -328,6 +336,12 @@ Enable additional tools with the `tools` parameter:
 
 ```
 https://mcp.exa.ai/mcp?exaApiKey=YOUR_KEY&tools=web_search_exa,web_search_advanced_exa,web_fetch_exa
+```
+
+If you want to use Exa Agent, enable all tools like so:
+
+```
+https://mcp.exa.ai/mcp?exaApiKey=YOUR_KEY&tools=agent_create_run,agent_wait_for_run,agent_get_run_output,agent_cancel_run
 ```
 
 ## Agent Skills (Claude Skills)

--- a/api/mcp.ts
+++ b/api/mcp.ts
@@ -7,6 +7,7 @@ import { initializeMcpServer } from '../src/mcp-handler.js';
 import { Ratelimit } from '@upstash/ratelimit';
 import { Redis } from '@upstash/redis';
 import { isJwtToken, verifyOAuthToken } from '../src/utils/auth.js';
+import { expandToolSelection } from '../src/toolRegistry.js';
 import {
   buildMcpClientMetadata,
   extractInitializeClientInfo,
@@ -438,10 +439,12 @@ async function getConfigFromRequest(request: Request): Promise<RequestConfig> {
     if (params.has('tools')) {
       const toolsParam = params.get('tools');
       if (toolsParam) {
-        enabledTools = toolsParam
+        enabledTools = expandToolSelection(
+          toolsParam
           .split(',')
           .map(t => t.trim())
-          .filter(t => t.length > 0);
+          .filter(t => t.length > 0),
+        );
       }
     }
 
@@ -466,10 +469,12 @@ async function getConfigFromRequest(request: Request): Promise<RequestConfig> {
 
   // Fall back to env vars if no query params were found
   if (!enabledTools && process.env.ENABLED_TOOLS) {
-    enabledTools = process.env.ENABLED_TOOLS
-      .split(',')
-      .map(t => t.trim())
-      .filter(t => t.length > 0);
+    enabledTools = expandToolSelection(
+      process.env.ENABLED_TOOLS
+        .split(',')
+        .map(t => t.trim())
+        .filter(t => t.length > 0),
+    );
   }
 
   if (!defaultSearchType && process.env.DEFAULT_SEARCH_TYPE) {

--- a/api/well-known-mcp-config.ts
+++ b/api/well-known-mcp-config.ts
@@ -28,7 +28,7 @@ const configSchema = {
         "web_search_exa,web_search_advanced_exa",
         "web_search_exa,web_search_advanced_exa,web_fetch_exa",
         "agent_tools",
-        "agent_create_run,agent_wait_for_run,agent_get_run_output,agent_cancel_run"
+        "web_search_exa,agent_tools"
       ],
       "x-available-values": AVAILABLE_TOOL_SELECTION_VALUES
     },

--- a/api/well-known-mcp-config.ts
+++ b/api/well-known-mcp-config.ts
@@ -5,7 +5,7 @@
  * the available configuration options and pass them via URL parameters.
  */
 
-import { AVAILABLE_TOOL_IDS } from "../src/toolRegistry.js";
+import { AVAILABLE_TOOL_SELECTION_VALUES } from "../src/toolRegistry.js";
 
 const configSchema = {
   "$schema": "http://json-schema.org/draft-07/schema#",
@@ -27,9 +27,10 @@ const configSchema = {
       "examples": [
         "web_search_exa,web_search_advanced_exa",
         "web_search_exa,web_search_advanced_exa,web_fetch_exa",
+        "agent_tools",
         "agent_create_run,agent_wait_for_run,agent_get_run_output,agent_cancel_run"
       ],
-      "x-available-values": AVAILABLE_TOOL_IDS
+      "x-available-values": AVAILABLE_TOOL_SELECTION_VALUES
     },
     "debug": {
       "type": "boolean",

--- a/api/well-known-mcp-config.ts
+++ b/api/well-known-mcp-config.ts
@@ -5,11 +5,7 @@
  * the available configuration options and pass them via URL parameters.
  */
 
-const AVAILABLE_TOOLS = [
-  'web_search_exa',
-  'web_search_advanced_exa',
-  'web_fetch_exa',
-];
+import { AVAILABLE_TOOL_IDS } from "../src/toolRegistry.js";
 
 const configSchema = {
   "$schema": "http://json-schema.org/draft-07/schema#",
@@ -27,12 +23,13 @@ const configSchema = {
     "tools": {
       "type": "string",
       "title": "Enabled Tools",
-      "description": "Comma-separated list of tools to enable. Leave empty for defaults (web_search_exa, web_fetch_exa).",
+      "description": "Comma-separated list of tools to enable. Leave empty for defaults (web_search_exa, web_fetch_exa). Agent tools require OAuth or an API key.",
       "examples": [
         "web_search_exa,web_search_advanced_exa",
-        "web_search_exa,web_search_advanced_exa,web_fetch_exa"
+        "web_search_exa,web_search_advanced_exa,web_fetch_exa",
+        "agent_create_run,agent_wait_for_run,agent_get_run_output,agent_cancel_run"
       ],
-      "x-available-values": AVAILABLE_TOOLS
+      "x-available-values": AVAILABLE_TOOL_IDS
     },
     "debug": {
       "type": "boolean",

--- a/env.example
+++ b/env.example
@@ -12,6 +12,10 @@ DEBUG=false
 #   - web_search_exa (enabled by default)
 #   - web_fetch_exa (enabled by default)
 #   - web_search_advanced_exa
+#   - agent_create_run (requires API key or OAuth)
+#   - agent_wait_for_run (requires API key or OAuth)
+#   - agent_get_run_output (requires API key or OAuth)
+#   - agent_cancel_run (requires API key or OAuth)
 #   - get_code_context_exa (deprecated)
 #   - company_research_exa (deprecated)
 #   - people_search_exa (deprecated)

--- a/npm.readme.md
+++ b/npm.readme.md
@@ -223,6 +223,14 @@ Standard `mcpServers` format:
 | ---- | ----------- |
 | `web_search_advanced_exa` | Advanced web search with full control over filters, domains, dates, and content options |
 
+**[Exa Agent](https://exa.ai/docs/reference/agent-api-guide) Tools** (optional, API key required):
+| Tool | Description |
+| ---- | ----------- |
+| `agent_create_run` | Start an async Exa Agent run for multi-step research, list-building, enrichment, or structured output |
+| `agent_wait_for_run` | Poll an Agent run until terminal status or timeout |
+| `agent_get_run_output` | Retrieve completed text, structured output, grounding, usage, and cost |
+| `agent_cancel_run` | Cancel a queued or running Agent run |
+
 **Deprecated** (still available for backwards compatibility):
 
 | Tool | Use instead |
@@ -240,6 +248,12 @@ Enable additional tools with the `tools` parameter:
 
 ```
 https://mcp.exa.ai/mcp?exaApiKey=YOUR_KEY&tools=web_search_exa,web_search_advanced_exa,web_fetch_exa
+```
+
+If you want to use Exa Agent, enable all tools like so:
+
+```
+https://mcp.exa.ai/mcp?exaApiKey=YOUR_KEY&tools=agent_create_run,agent_wait_for_run,agent_get_run_output,agent_cancel_run
 ```
 
 See the [full documentation](https://docs.exa.ai/reference/exa-mcp) for more details on tool configuration.

--- a/npm.readme.md
+++ b/npm.readme.md
@@ -250,10 +250,16 @@ Enable additional tools with the `tools` parameter:
 https://mcp.exa.ai/mcp?exaApiKey=YOUR_KEY&tools=web_search_exa,web_search_advanced_exa,web_fetch_exa
 ```
 
-If you want to use Exa Agent, enable all tools like so:
+If you want to use Exa Agent, enable the optional toolset like so:
 
 ```
-https://mcp.exa.ai/mcp?exaApiKey=YOUR_KEY&tools=agent_create_run,agent_wait_for_run,agent_get_run_output,agent_cancel_run
+https://mcp.exa.ai/mcp?tools=agent_tools
+```
+
+If you want both search and Exa Agent tools enabled:
+
+```
+https://mcp.exa.ai/mcp?tools=web_search_exa,agent_tools
 ```
 
 See the [full documentation](https://docs.exa.ai/reference/exa-mcp) for more details on tool configuration.

--- a/npm.readme.md
+++ b/npm.readme.md
@@ -259,7 +259,7 @@ https://mcp.exa.ai/mcp?tools=agent_tools
 If you want both search and Exa Agent tools enabled:
 
 ```
-https://mcp.exa.ai/mcp?tools=web_search_exa,agent_tools
+https://mcp.exa.ai/mcp?tools=web_search_exa,web_fetch_exa,agent_tools
 ```
 
 See the [full documentation](https://docs.exa.ai/reference/exa-mcp) for more details on tool configuration.

--- a/package.json
+++ b/package.json
@@ -13,13 +13,15 @@
     "exa-mcp-server": "dist/stdio.cjs"
   },
   "files": [
-    "dist"
+    "dist",
+    "skills"
   ],
   "keywords": [
     "mcp",
     "search mcp",
     "model context protocol",
     "exa",
+    "agent",
     "search",
     "websearch",
     "claude",

--- a/skills/agent/SKILL.md
+++ b/skills/agent/SKILL.md
@@ -1,0 +1,278 @@
+---
+name: exa-agent
+description: Use Exa Agent for async, multi-step web research, list-building, enrichment, structured output, run continuation, and coverage validation.
+---
+
+# Exa Agent Research
+
+You are operating Exa Agent through MCP. Exa Agent is async and run-ID based: create a run, monitor status/events, retrieve output, and continue with follow-up runs when needed.
+
+## Required tools
+
+- `agent_create_run`
+- `agent_wait_for_run`
+- `agent_get_run_output`
+- `agent_cancel_run`
+
+## Exa Connect providers
+
+When a run needs premium partner data alongside Exa web search, pass `dataSources` to `agent_create_run`.
+
+Use only the currently usable self-serve providers:
+
+- `fiber_ai`: B2B company, people, jobs, and contact enrichment
+- `financial_datasets`: ticker-based news for US public companies
+- `similar_web`: website traffic estimates, rankings, and competitor discovery
+- `baselayer`: US business verification, officers, registrations, and KYB
+- `affiliate`: product catalog search, pricing, brands, and merchant links
+- `particle_news`: podcast transcript search with speaker attribution and timestamps
+- `jinko`: travel destination discovery ranked by fare
+
+Do not suggest request-only providers unless the user explicitly says their Exa account already has them enabled.
+
+## Decision tree
+
+Choose the work surface before acting:
+
+1. Known input rows plus repeated same-shape enrichment at scale
+   - Write a deterministic script using Exa APIs directly.
+   - Use bounded concurrency, exponential backoff, checkpoints, and a stable output file.
+   - Read the output file and synthesize from it.
+   - Do not burn context manually looping over hundreds of identical tool calls.
+
+2. Open-ended universe definition, list-building, people/company discovery, multi-hop research, structured research, or follow-up over previous work
+   - Use Exa Agent.
+   - Define the objective and `outputSchema` before creating the run.
+
+## Before creating a run
+
+Always write down:
+
+- Objective: what the run is meant to answer.
+- Universe: what entities qualify.
+- Segments: geographies, industries, personas, dates, asset classes, or other partitions.
+- Coverage target: desired count, maximum count, and what "good enough" means.
+- Output fields: columns needed in the final answer.
+- Evidence requirements: URLs, source titles, dates, and confidence.
+- Exclusions: prior results or disallowed entities.
+
+If the user uses relative time like "recent", "last 6 months", or "post-IPO", calculate exact dates from today's date first.
+
+## Schema rules
+
+Use `outputSchema` for list-building, enrichment, finance/company research, and repeatable workflows.
+
+Rules:
+
+- Use a top-level object.
+- Put list rows in a named array field.
+- Add `maxItems` to arrays when possible.
+- Include source/evidence fields, not just conclusions.
+- Include stable identifiers: company name, website/domain, person LinkedIn URL, ticker, CIK, etc.
+- Include confidence or rationale fields for fuzzy judgments.
+- Keep required fields limited to what must exist.
+- Use `format: "uri"`, `format: "email"`, or `format: "phone"` when needed.
+
+Example company-list schema:
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "companies": {
+      "type": "array",
+      "maxItems": 50,
+      "items": {
+        "type": "object",
+        "properties": {
+          "company_name": { "type": "string" },
+          "website": { "type": "string", "format": "uri" },
+          "segment": { "type": "string" },
+          "why_it_qualifies": { "type": "string" },
+          "evidence_url": { "type": "string", "format": "uri" },
+          "confidence": { "type": "string", "enum": ["low", "medium", "high"] }
+        },
+        "required": ["company_name", "website", "why_it_qualifies", "evidence_url"]
+      }
+    },
+    "coverage_notes": { "type": "string" },
+    "known_gaps": {
+      "type": "array",
+      "items": { "type": "string" }
+    }
+  },
+  "required": ["companies", "coverage_notes"]
+}
+```
+
+Example with Exa Connect:
+
+```json
+{
+  "tool": "agent_create_run",
+  "arguments": {
+    "query": "Find 10 fast-growing B2B SaaS companies and return estimated monthly website visits from Similarweb.",
+    "dataSources": [
+      { "provider": "similar_web" }
+    ],
+    "outputSchema": {
+      "type": "object",
+      "properties": {
+        "companies": {
+          "type": "array",
+          "maxItems": 10,
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": { "type": "string" },
+              "domain": { "type": "string" },
+              "monthlyVisits": {
+                "type": "number",
+                "description": "Estimated monthly visits from Similarweb"
+              }
+            },
+            "required": ["name", "domain", "monthlyVisits"]
+          }
+        }
+      },
+      "required": ["companies"]
+    }
+  }
+}
+```
+
+## Exa Agent workflow
+
+1. Create the run
+   - Call `agent_create_run`.
+   - Use `effort: "auto"` unless the user requests speed/depth.
+   - Include `outputSchema` for structured work.
+   - Use `input.data` for known rows.
+   - Use `input.exclusion` for entities already returned or disallowed.
+   - Add `dataSources` only when one of the self-serve Exa Connect providers is clearly useful.
+   - Name the provider-specific data you want in both the query and the schema so Agent uses the provider instead of falling back to web search.
+
+2. Save the run ID
+   - Always keep the `agent_run_...` ID in your working notes.
+   - Include run IDs in final reports.
+
+3. Monitor
+   - Prefer `agent_wait_for_run` with a bounded timeout.
+   - If still running, call it again.
+   - Treat `agent_wait_for_run` as the default status surface.
+
+4. Retrieve output
+   - When status is `completed`, call `agent_get_run_output`.
+   - Read both `output.structured` and `output.grounding`.
+   - Do not assume results are exhaustive just because the run completed.
+
+5. Validate coverage
+   - Check row count against target.
+   - Check segment coverage.
+   - Deduplicate entities.
+   - Inspect evidence quality.
+   - Identify gaps.
+
+6. Continue if needed
+   - Use `agent_create_run` with `previousRunId` for follow-up/refinement.
+   - Use `input.exclusion` to avoid resurfacing prior results.
+   - Segment large universes into multiple runs if one run is too broad.
+
+7. Final answer
+   - State what was done.
+   - Include run IDs.
+   - Present structured results.
+   - State coverage and limitations.
+   - Say "best-effort discovery" unless exhaustiveness was explicitly scoped and validated.
+
+## Continuation patterns
+
+Use `previousRunId` when:
+
+- narrowing a list
+- filling missing fields
+- asking for another segment
+- validating a prior set
+- requesting "more like these"
+
+Do not use `previousRunId` when:
+
+- the prior run failed or is still running
+- the new task is unrelated
+- you need clean independent coverage for another segment
+
+For independent segments, create separate runs and aggregate results yourself.
+
+## Exhaustiveness and coverage language
+
+Never claim exhaustive coverage unless all are true:
+
+- The universe is bounded and well-defined.
+- Search/discovery strategy covers the main segments.
+- The output count and gaps were checked.
+- Duplicates were resolved.
+- Evidence was inspected.
+- Any remaining unknowns are disclosed.
+
+Preferred language when not fully validated:
+
+- "best-effort discovery"
+- "high-confidence initial universe"
+- "not exhaustive"
+- "coverage appears strongest in X and weaker in Y"
+
+Avoid:
+
+- "all companies"
+- "complete list"
+- "exhaustive"
+- "definitive"
+
+unless validation supports it.
+
+## Batch Script Mode
+
+If the task requires many parallel Exa calls of the same shape, especially batch enrichment over known companies/people:
+
+1. Write a script instead of issuing many MCP calls manually.
+2. The script must:
+   - read deterministic inputs from a file
+   - use bounded concurrency
+   - use exponential backoff for 429/5xx
+   - checkpoint partial progress
+   - write deterministic JSON/CSV/TSV output
+   - preserve raw API errors per row
+3. Run the script.
+4. Read the output file.
+5. Synthesize from the output.
+
+Use Exa Agent instead of Batch Script Mode when the hard part is discovery, reasoning, multi-hop research, or deciding what to search next.
+
+## Failure handling
+
+If create fails:
+
+- Surface the HTTP error and fix schema/auth/input.
+- Do not silently fall back to generic web search for Exa Agent-shaped work.
+
+If wait times out:
+
+- The run may still be healthy.
+- Call `agent_wait_for_run` again.
+
+If the run fails:
+
+- Explain the failure from the returned terminal status.
+- Create a corrected follow-up/new run only if the correction is clear.
+
+If the run objective/schema is wrong:
+
+- Cancel it with `agent_cancel_run`.
+- Start a corrected run.
+
+If output is sparse:
+
+- Continue with `previousRunId`.
+- Add exclusions for prior results.
+- Segment the universe.
+- Tighten or clarify schema fields.

--- a/src/mcp-handler.ts
+++ b/src/mcp-handler.ts
@@ -1,4 +1,3 @@
-import { z } from "zod";
 import { trackMCP, createConfig } from 'agnost';
 
 // Import tool implementations
@@ -12,22 +11,18 @@ import { registerDeepResearchCheckTool } from "./tools/deepResearchCheck.js";
 import { registerExaCodeTool } from "./tools/exaCode.js";
 import { registerWebSearchAdvancedTool } from "./tools/webSearchAdvanced.js";
 import { registerDeepSearchTool } from "./tools/deepSearch.js";
+import { registerAgentCreateRunTool } from "./tools/agentCreateRun.js";
+import { registerAgentWaitForRunTool } from "./tools/agentWaitForRun.js";
+import { registerAgentGetRunOutputTool } from "./tools/agentGetRunOutput.js";
+import { registerAgentCancelRunTool } from "./tools/agentCancelRun.js";
+import {
+  TOOL_REGISTRY,
+  isAgentTool,
+  listToolMetadata,
+  requiresUserProvidedApiKey,
+  type ToolId,
+} from "./toolRegistry.js";
 import { log } from "./utils/logger.js";
-
-// Tool registry for managing available tools
-const availableTools = {
-  'web_search_exa': { name: 'Web Search (Exa)', description: 'Real-time web search using Exa AI', enabled: true },
-  'web_search_advanced_exa': { name: 'Advanced Web Search (Exa)', description: 'Advanced web search with full Exa API control including category filters, domain restrictions, date ranges, highlights, summaries, and subpage crawling', enabled: false },
-  'get_code_context_exa': { name: 'Code Context Search (Deprecated)', description: 'Deprecated: Use web_search_exa instead. Search for code snippets, examples, and documentation from open source repositories', enabled: false },
-  'company_research_exa': { name: 'Company Research (Deprecated)', description: 'Deprecated: Use web_search_advanced_exa instead. Research companies and organizations', enabled: false },
-  'web_fetch_exa': { name: 'Web Crawling', description: 'Extract content from specific URLs', enabled: true },
-  'deep_researcher_start': { name: 'Deep Researcher Start (Deprecated)', description: 'Deprecated: Start a comprehensive AI research task', enabled: false },
-  'deep_researcher_check': { name: 'Deep Researcher Check (Deprecated)', description: 'Deprecated: Check status and retrieve results of research task', enabled: false },
-  'people_search_exa': { name: 'People Search (Deprecated)', description: 'Deprecated: Use web_search_advanced_exa instead. Search for people and professional profiles', enabled: false },
-  'linkedin_search_exa': { name: 'LinkedIn Search (Deprecated)', description: 'Deprecated: Use web_search_advanced_exa instead', enabled: false },
-  'deep_search_exa': { name: 'Deep Search (Deprecated)', description: 'Deprecated: Use web_search_advanced_exa instead. Deep search with query expansion and synthesized answers (requires API key)', enabled: false },
-  'crawling_exa': { name: 'Web Crawling (Deprecated)', description: 'Deprecated: Use web_fetch_exa instead. Extract content from specific URLs', enabled: false },
-};
 
 export interface McpConfig {
   exaApiKey?: string;
@@ -57,78 +52,109 @@ export function initializeMcpServer(server: any, config: McpConfig = {}) {
     }
 
     // Helper function to check if a tool should be registered
-    const shouldRegisterTool = (toolId: string): boolean => {
+    const shouldRegisterTool = (toolId: ToolId): boolean => {
       if (config.enabledTools && config.enabledTools.length > 0) {
         return config.enabledTools.includes(toolId);
       }
-      return availableTools[toolId as keyof typeof availableTools]?.enabled ?? false;
+      return TOOL_REGISTRY[toolId]?.enabled ?? false;
+    };
+
+    const canRegisterTool = (toolId: ToolId): boolean => {
+      if (!shouldRegisterTool(toolId)) {
+        return false;
+      }
+
+      if (requiresUserProvidedApiKey(toolId) && !config.userProvidedApiKey) {
+        return false;
+      }
+
+      return true;
     };
 
     // Register tools based on configuration
     const registeredTools: string[] = [];
-    
-    if (shouldRegisterTool('web_search_exa')) {
+
+    if (canRegisterTool('web_search_exa')) {
       registerWebSearchTool(server, config);
       registeredTools.push('web_search_exa');
     }
-    
-    if (shouldRegisterTool('web_search_advanced_exa')) {
+
+    if (canRegisterTool('web_search_advanced_exa')) {
       registerWebSearchAdvancedTool(server, config);
       registeredTools.push('web_search_advanced_exa');
     }
-    
-    if (shouldRegisterTool('company_research_exa')) {
+
+    if (canRegisterTool('company_research_exa')) {
       registerCompanyResearchTool(server, config);
       registeredTools.push('company_research_exa');
     }
-    
-    if (shouldRegisterTool('web_fetch_exa')) {
+
+    if (canRegisterTool('web_fetch_exa')) {
       registerWebFetchTool(server, config);
       registeredTools.push('web_fetch_exa');
     }
 
     // Deprecated: crawling_exa - kept for backwards compatibility, points to web_fetch_exa
-    if (shouldRegisterTool('crawling_exa')) {
+    if (canRegisterTool('crawling_exa')) {
       registerWebFetchTool(server, config, 'crawling_exa');
       registeredTools.push('crawling_exa');
     }
 
-    if (shouldRegisterTool('people_search_exa')) {
+    if (canRegisterTool('people_search_exa')) {
       registerPeopleSearchTool(server, config);
       registeredTools.push('people_search_exa');
     }
-    
+
     // Deprecated: linkedin_search_exa - kept for backwards compatibility
-    if (shouldRegisterTool('linkedin_search_exa')) {
+    if (canRegisterTool('linkedin_search_exa')) {
       registerLinkedInSearchTool(server, config);
       registeredTools.push('linkedin_search_exa');
     }
-    
-    if (shouldRegisterTool('deep_researcher_start')) {
+
+    if (canRegisterTool('deep_researcher_start')) {
       registerDeepResearchStartTool(server, config);
       registeredTools.push('deep_researcher_start');
     }
-    
-    if (shouldRegisterTool('deep_researcher_check')) {
+
+    if (canRegisterTool('deep_researcher_check')) {
       registerDeepResearchCheckTool(server, config);
       registeredTools.push('deep_researcher_check');
     }
-    
-    if (shouldRegisterTool('get_code_context_exa')) {
+
+    if (canRegisterTool('get_code_context_exa')) {
       registerExaCodeTool(server, config);
       registeredTools.push('get_code_context_exa');
     }
-    
-    // deep_search_exa requires the user to have provided their own API key
-    if (shouldRegisterTool('deep_search_exa') && config.userProvidedApiKey) {
+
+    if (canRegisterTool('deep_search_exa')) {
       registerDeepSearchTool(server, config);
       registeredTools.push('deep_search_exa');
     }
-    
+
+    if (canRegisterTool("agent_create_run")) {
+      registerAgentCreateRunTool(server, config);
+      registeredTools.push("agent_create_run");
+    }
+
+    if (canRegisterTool("agent_wait_for_run")) {
+      registerAgentWaitForRunTool(server, config);
+      registeredTools.push("agent_wait_for_run");
+    }
+
+    if (canRegisterTool("agent_get_run_output")) {
+      registerAgentGetRunOutputTool(server, config);
+      registeredTools.push("agent_get_run_output");
+    }
+
+    if (canRegisterTool("agent_cancel_run")) {
+      registerAgentCancelRunTool(server, config);
+      registeredTools.push("agent_cancel_run");
+    }
+
     if (config.debug) {
       log(`Registered ${registeredTools.length} tools: ${registeredTools.join(', ')}`);
     }
-    
+
     // Register prompts to help users get started
     server.prompt(
       "web_search_help",
@@ -149,6 +175,8 @@ export function initializeMcpServer(server: any, config: McpConfig = {}) {
       }
     );
 
+    const registeredAgentTools = registeredTools.filter((toolId) => isAgentTool(toolId as ToolId));
+
     // Register resources to expose server information
     server.resource(
       "tools_list",
@@ -158,17 +186,10 @@ export function initializeMcpServer(server: any, config: McpConfig = {}) {
         description: "List of available Exa tools and their descriptions"
       },
       async () => {
-        const toolsList = Object.entries(availableTools).map(([id, tool]) => ({
-          id,
-          name: tool.name,
-          description: tool.description,
-          enabled: registeredTools.includes(id)
-        }));
-        
         return {
           contents: [{
             uri: "exa://tools/list",
-            text: JSON.stringify(toolsList, null, 2),
+            text: JSON.stringify(listToolMetadata(registeredTools), null, 2),
             mimeType: "application/json"
           }]
         };

--- a/src/mcp-handler.ts
+++ b/src/mcp-handler.ts
@@ -1,4 +1,5 @@
 import { trackMCP, createConfig } from 'agnost';
+import { z } from "zod";
 
 // Import tool implementations
 import { registerWebSearchTool } from "./tools/webSearch.js";
@@ -15,6 +16,7 @@ import { registerAgentCreateRunTool } from "./tools/agentCreateRun.js";
 import { registerAgentWaitForRunTool } from "./tools/agentWaitForRun.js";
 import { registerAgentGetRunOutputTool } from "./tools/agentGetRunOutput.js";
 import { registerAgentCancelRunTool } from "./tools/agentCancelRun.js";
+import { agentSchemaTemplates } from "./tools/agentSchemaTemplates.js";
 import {
   TOOL_REGISTRY,
   isAgentTool,
@@ -23,6 +25,7 @@ import {
   type ToolId,
 } from "./toolRegistry.js";
 import { log } from "./utils/logger.js";
+import { loadAgentSkillContent } from "./utils/agentSkill.js";
 
 export interface McpConfig {
   exaApiKey?: string;
@@ -177,6 +180,50 @@ export function initializeMcpServer(server: any, config: McpConfig = {}) {
 
     const registeredAgentTools = registeredTools.filter((toolId) => isAgentTool(toolId as ToolId));
 
+    if (registeredAgentTools.length > 0) {
+      const agentSkillContent = loadAgentSkillContent();
+
+      server.prompt(
+        "agent_research_help",
+        "Get help structuring a multi-step Exa Agent research run.",
+        {
+          task: z
+            .string()
+            .optional()
+            .describe("The research task to turn into an Exa Agent run"),
+        },
+        async (args?: { task?: string }) => {
+          const task = args?.task?.trim();
+          const taskLine = task
+            ? `My research task:\n\n${task}`
+            : "Help me turn my research task into an Exa Agent run with a clear objective, bounded output schema, coverage plan, and follow-up strategy.";
+
+          return {
+            messages: [
+              {
+                role: "user",
+                content: {
+                  type: "text",
+                  text: `${taskLine}\n\nFollow the Exa Agent research guide below.`,
+                },
+              },
+              {
+                role: "user",
+                content: {
+                  type: "resource",
+                  resource: {
+                    uri: "exa://agent/skill",
+                    mimeType: "text/markdown",
+                    text: agentSkillContent,
+                  },
+                },
+              },
+            ],
+          };
+        },
+      );
+    }
+
     // Register resources to expose server information
     server.resource(
       "tools_list",
@@ -195,6 +242,42 @@ export function initializeMcpServer(server: any, config: McpConfig = {}) {
         };
       }
     );
+
+    if (registeredAgentTools.length > 0) {
+      const agentSkillContent = loadAgentSkillContent();
+
+      server.resource(
+        "agent_research_guide",
+        "exa://agent/skill",
+        {
+          mimeType: "text/markdown",
+          description: "Exa Agent research workflow, schema rules, and coverage guidance",
+        },
+        async () => ({
+          contents: [{
+            uri: "exa://agent/skill",
+            text: agentSkillContent,
+            mimeType: "text/markdown",
+          }],
+        }),
+      );
+
+      server.resource(
+        "agent_schema_templates",
+        "exa://agent/schema-templates",
+        {
+          mimeType: "application/json",
+          description: "Starter JSON Schema templates for common Agent workflows",
+        },
+        async () => ({
+          contents: [{
+            uri: "exa://agent/schema-templates",
+            text: JSON.stringify(agentSchemaTemplates, null, 2),
+            mimeType: "application/json",
+          }],
+        }),
+      );
+    }
     
     // Add Agnost analytics tracking (works with both McpServer and mcp-handler)
     // The server object might be wrapped, so we try to access the underlying server

--- a/src/stdio.ts
+++ b/src/stdio.ts
@@ -28,6 +28,8 @@ export function buildConfigFromEnv(env: NodeJS.ProcessEnv = process.env): McpCon
     exaApiKey,
     enabledTools: parseTools(env.ENABLED_TOOLS ?? env.TOOLS),
     debug: env.DEBUG === "true",
+    exaSource: env.EXA_SOURCE,
+    mcpSessionId: env.MCP_SESSION_ID,
     defaultSearchType: parseSearchType(env.DEFAULT_SEARCH_TYPE),
     userProvidedApiKey: Boolean(exaApiKey),
   };

--- a/src/stdio.ts
+++ b/src/stdio.ts
@@ -3,6 +3,7 @@ process.env.AGNOST_LOG_LEVEL = process.env.AGNOST_LOG_LEVEL ?? "error";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { initializeMcpServer, type McpConfig } from "./mcp-handler.js";
+import { expandToolSelection } from "./toolRegistry.js";
 import { log } from "./utils/logger.js";
 
 // Reads EXA_API_KEY, ENABLED_TOOLS / TOOLS, DEBUG, DEFAULT_SEARCH_TYPE from env.
@@ -10,10 +11,12 @@ import { log } from "./utils/logger.js";
 
 function parseTools(value: string | undefined): string[] | undefined {
   if (!value) return undefined;
-  const tools = value
+  const tools = expandToolSelection(
+    value
     .split(",")
     .map(tool => tool.trim())
-    .filter(tool => tool.length > 0);
+    .filter(tool => tool.length > 0),
+  );
   return tools.length > 0 ? tools : undefined;
 }
 

--- a/src/toolRegistry.ts
+++ b/src/toolRegistry.ts
@@ -114,6 +114,17 @@ export const AGENT_TOOL_IDS = AVAILABLE_TOOL_IDS.filter(
   (toolId) => TOOL_REGISTRY[toolId].group === "agent",
 );
 
+export const TOOL_SELECTION_ALIASES = {
+  agent_tools: AGENT_TOOL_IDS,
+} as const;
+
+export type ToolSelectionValue = ToolId | keyof typeof TOOL_SELECTION_ALIASES;
+
+export const AVAILABLE_TOOL_SELECTION_VALUES = [
+  ...AVAILABLE_TOOL_IDS,
+  ...Object.keys(TOOL_SELECTION_ALIASES),
+] as ToolSelectionValue[];
+
 export function isToolEnabledByDefault(toolId: ToolId): boolean {
   return TOOL_REGISTRY[toolId].enabled;
 }
@@ -134,4 +145,25 @@ export function listToolMetadata(registeredTools: string[]) {
     description: TOOL_REGISTRY[toolId].description,
     enabled: registeredTools.includes(toolId),
   }));
+}
+
+export function expandToolSelection(values: string[]): ToolId[] {
+  const expanded: ToolId[] = [];
+  const seen = new Set<ToolId>();
+
+  for (const value of values) {
+    const aliasTools = TOOL_SELECTION_ALIASES[value as keyof typeof TOOL_SELECTION_ALIASES];
+    const toolIds = aliasTools ?? [value as ToolId];
+
+    for (const toolId of toolIds) {
+      if (!(toolId in TOOL_REGISTRY) || seen.has(toolId)) {
+        continue;
+      }
+
+      seen.add(toolId);
+      expanded.push(toolId);
+    }
+  }
+
+  return expanded;
 }

--- a/src/toolRegistry.ts
+++ b/src/toolRegistry.ts
@@ -1,0 +1,137 @@
+export type ToolGroup = "search" | "agent";
+
+export type ToolMetadata = {
+  name: string;
+  description: string;
+  enabled: boolean;
+  group: ToolGroup;
+  requiresUserProvidedApiKey?: boolean;
+};
+
+export const TOOL_REGISTRY = {
+  web_search_exa: {
+    name: "Web Search (Exa)",
+    description: "Real-time web search using Exa AI",
+    enabled: true,
+    group: "search",
+  },
+  web_search_advanced_exa: {
+    name: "Advanced Web Search (Exa)",
+    description: "Advanced web search with full Exa API control including category filters, domain restrictions, date ranges, highlights, summaries, and subpage crawling",
+    enabled: false,
+    group: "search",
+  },
+  get_code_context_exa: {
+    name: "Code Context Search (Deprecated)",
+    description: "Deprecated: Use web_search_exa instead. Search for code snippets, examples, and documentation from open source repositories",
+    enabled: false,
+    group: "search",
+  },
+  company_research_exa: {
+    name: "Company Research (Deprecated)",
+    description: "Deprecated: Use web_search_advanced_exa instead. Research companies and organizations",
+    enabled: false,
+    group: "search",
+  },
+  web_fetch_exa: {
+    name: "Web Crawling",
+    description: "Extract content from specific URLs",
+    enabled: true,
+    group: "search",
+  },
+  deep_researcher_start: {
+    name: "Deep Researcher Start (Deprecated)",
+    description: "Deprecated: Start a comprehensive AI research task",
+    enabled: false,
+    group: "search",
+  },
+  deep_researcher_check: {
+    name: "Deep Researcher Check (Deprecated)",
+    description: "Deprecated: Check status and retrieve results of research task",
+    enabled: false,
+    group: "search",
+  },
+  people_search_exa: {
+    name: "People Search (Deprecated)",
+    description: "Deprecated: Use web_search_advanced_exa instead. Search for people and professional profiles",
+    enabled: false,
+    group: "search",
+  },
+  linkedin_search_exa: {
+    name: "LinkedIn Search (Deprecated)",
+    description: "Deprecated: Use web_search_advanced_exa instead",
+    enabled: false,
+    group: "search",
+  },
+  deep_search_exa: {
+    name: "Deep Search (Deprecated)",
+    description: "Deprecated: Use web_search_advanced_exa instead. Deep search with query expansion and synthesized answers (requires API key)",
+    enabled: false,
+    group: "search",
+    requiresUserProvidedApiKey: true,
+  },
+  crawling_exa: {
+    name: "Web Crawling (Deprecated)",
+    description: "Deprecated: Use web_fetch_exa instead. Extract content from specific URLs",
+    enabled: false,
+    group: "search",
+  },
+  agent_create_run: {
+    name: "Create Exa Agent Run",
+    description: "Start an async Exa Agent run for multi-step research, list-building, enrichment, or structured output.",
+    enabled: false,
+    group: "agent",
+    requiresUserProvidedApiKey: true,
+  },
+  agent_wait_for_run: {
+    name: "Wait for Exa Agent Run",
+    description: "Poll an Exa Agent run until terminal status or a bounded timeout.",
+    enabled: false,
+    group: "agent",
+    requiresUserProvidedApiKey: true,
+  },
+  agent_get_run_output: {
+    name: "Get Exa Agent Run Output",
+    description: "Retrieve completed text, structured output, grounding, usage, and cost.",
+    enabled: false,
+    group: "agent",
+    requiresUserProvidedApiKey: true,
+  },
+  agent_cancel_run: {
+    name: "Cancel Exa Agent Run",
+    description: "Cancel a queued or running Exa Agent run.",
+    enabled: false,
+    group: "agent",
+    requiresUserProvidedApiKey: true,
+  },
+} as const satisfies Record<string, ToolMetadata>;
+
+export type ToolId = keyof typeof TOOL_REGISTRY;
+
+export const AVAILABLE_TOOL_IDS = Object.keys(TOOL_REGISTRY) as ToolId[];
+
+export const AGENT_TOOL_IDS = AVAILABLE_TOOL_IDS.filter(
+  (toolId) => TOOL_REGISTRY[toolId].group === "agent",
+);
+
+export function isToolEnabledByDefault(toolId: ToolId): boolean {
+  return TOOL_REGISTRY[toolId].enabled;
+}
+
+export function requiresUserProvidedApiKey(toolId: ToolId): boolean {
+  const tool = TOOL_REGISTRY[toolId];
+  return "requiresUserProvidedApiKey" in tool && tool.requiresUserProvidedApiKey === true;
+}
+
+export function isAgentTool(toolId: ToolId): boolean {
+  return TOOL_REGISTRY[toolId].group === "agent";
+}
+
+export function listToolMetadata(registeredTools: string[]) {
+  return AVAILABLE_TOOL_IDS.map((toolId) => ({
+    id: toolId,
+    name: TOOL_REGISTRY[toolId].name,
+    description: TOOL_REGISTRY[toolId].description,
+    enabled: registeredTools.includes(toolId),
+  }));
+}

--- a/src/tools/agentCancelRun.ts
+++ b/src/tools/agentCancelRun.ts
@@ -6,11 +6,7 @@ import { formatAgentToolError } from "../utils/agentErrorHandler.js";
 import { createRequestLogger } from "../utils/logger.js";
 import { jsonContent } from "../utils/response.js";
 
-type AgentToolConfig = AgentApiClientConfig & {
-  userProvidedApiKey?: boolean;
-};
-
-export function registerAgentCancelRunTool(server: McpServer, config?: AgentToolConfig): void {
+export function registerAgentCancelRunTool(server: McpServer, config?: AgentApiClientConfig): void {
   server.tool(
     "agent_cancel_run",
     "Cancel a queued or running Exa Agent run. Use only when the user asks, the run is clearly wrong, or a duplicate run was accidentally created.",
@@ -41,7 +37,7 @@ export function registerAgentCancelRunTool(server: McpServer, config?: AgentTool
         });
       } catch (error) {
         logger.error(error);
-        return formatAgentToolError(error, "agent_cancel_run", config?.userProvidedApiKey);
+        return formatAgentToolError(error, "agent_cancel_run");
       }
     },
   );

--- a/src/tools/agentCancelRun.ts
+++ b/src/tools/agentCancelRun.ts
@@ -1,0 +1,48 @@
+import { z } from "zod";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { checkpoint } from "agnost";
+import { AgentApiClient, type AgentApiClientConfig } from "../utils/agentApiClient.js";
+import { formatAgentToolError } from "../utils/agentErrorHandler.js";
+import { createRequestLogger } from "../utils/logger.js";
+import { jsonContent } from "../utils/response.js";
+
+type AgentToolConfig = AgentApiClientConfig & {
+  userProvidedApiKey?: boolean;
+};
+
+export function registerAgentCancelRunTool(server: McpServer, config?: AgentToolConfig): void {
+  server.tool(
+    "agent_cancel_run",
+    "Cancel a queued or running Exa Agent run. Use only when the user asks, the run is clearly wrong, or a duplicate run was accidentally created.",
+    {
+      runId: z.string().min(1).describe("The agent_run_... ID to cancel."),
+    },
+    {
+      readOnlyHint: false,
+      destructiveHint: false,
+      idempotentHint: true,
+    },
+    async ({ runId }) => {
+      const requestId = `agent_cancel_run-${Date.now()}-${Math.random().toString(36).slice(2, 7)}`;
+      const logger = createRequestLogger(requestId, "agent_cancel_run");
+      logger.start(runId);
+
+      try {
+        const run = await new AgentApiClient(config).cancelRun(runId);
+        checkpoint("agent_cancel_run_response_received", { status: run.status });
+        logger.complete();
+
+        return jsonContent({
+          success: true,
+          id: run.id,
+          status: run.status,
+          nextAction: "Create a corrected run if the task still needs to be completed.",
+          run,
+        });
+      } catch (error) {
+        logger.error(error);
+        return formatAgentToolError(error, "agent_cancel_run", config?.userProvidedApiKey);
+      }
+    },
+  );
+}

--- a/src/tools/agentCreateRun.ts
+++ b/src/tools/agentCreateRun.ts
@@ -19,11 +19,7 @@ const dataSourceProviderSchema = z.enum([
   "jinko",
 ]);
 
-type AgentToolConfig = AgentApiClientConfig & {
-  userProvidedApiKey?: boolean;
-};
-
-export function registerAgentCreateRunTool(server: McpServer, config?: AgentToolConfig): void {
+export function registerAgentCreateRunTool(server: McpServer, config?: AgentApiClientConfig): void {
   server.tool(
     "agent_create_run",
     "Create an async Exa Agent run for multi-step research, list-building, enrichment, or structured output. Returns an agent_run_... ID immediately; poll with agent_wait_for_run before reading final output. Every run should include outputSchema when repeatable structured results are needed.",
@@ -86,7 +82,7 @@ export function registerAgentCreateRunTool(server: McpServer, config?: AgentTool
         });
       } catch (error) {
         logger.error(error);
-        return formatAgentToolError(error, "agent_create_run", config?.userProvidedApiKey);
+        return formatAgentToolError(error, "agent_create_run");
       }
     },
   );

--- a/src/tools/agentCreateRun.ts
+++ b/src/tools/agentCreateRun.ts
@@ -1,0 +1,93 @@
+import { z } from "zod";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { checkpoint } from "agnost";
+import type { AgentEffort, AgentRunInput } from "../types.js";
+import { AgentApiClient, type AgentApiClientConfig } from "../utils/agentApiClient.js";
+import { formatAgentToolError } from "../utils/agentErrorHandler.js";
+import { createRequestLogger } from "../utils/logger.js";
+import { jsonContent } from "../utils/response.js";
+
+const effortSchema = z.enum(["low", "medium", "high", "xhigh", "auto"]);
+const recordSchema = z.record(z.unknown());
+const dataSourceProviderSchema = z.enum([
+  "fiber_ai",
+  "financial_datasets",
+  "similar_web",
+  "baselayer",
+  "affiliate",
+  "particle_news",
+  "jinko",
+]);
+
+type AgentToolConfig = AgentApiClientConfig & {
+  userProvidedApiKey?: boolean;
+};
+
+export function registerAgentCreateRunTool(server: McpServer, config?: AgentToolConfig): void {
+  server.tool(
+    "agent_create_run",
+    "Create an async Exa Agent run for multi-step research, list-building, enrichment, or structured output. Returns an agent_run_... ID immediately; poll with agent_wait_for_run before reading final output. Every run should include outputSchema when repeatable structured results are needed.",
+    {
+      query: z.string().min(1).describe("Natural-language research or enrichment objective."),
+      systemPrompt: z.string().optional().describe("Optional system-level guidance for the Agent."),
+      outputSchema: recordSchema.optional().describe("Optional JSON Schema for output. Prefer a top-level object with bounded arrays and source/evidence fields."),
+      input: z.object({
+        data: z.array(recordSchema).optional().describe("Known rows/entities to enrich or process."),
+        exclusion: z.array(recordSchema).optional().describe("Entities, rows, or records Agent should avoid returning again."),
+      }).optional(),
+      dataSources: z.array(z.object({
+        provider: dataSourceProviderSchema.describe("Exa Connect provider to enable for the run."),
+      })).max(5).optional().describe("Optional Exa Connect providers to enable for this run. Usable self-serve providers: fiber_ai, financial_datasets, similar_web, baselayer, affiliate, particle_news, jinko."),
+      previousRunId: z.string().optional().describe("Completed prior agent_run_... ID to continue from."),
+      effort: effortSchema.optional().describe("Agent effort: low, medium, high, xhigh, or auto. Defaults to auto."),
+    },
+    {
+      readOnlyHint: false,
+      destructiveHint: false,
+      idempotentHint: false,
+    },
+    async ({ query, systemPrompt, outputSchema, input, dataSources, previousRunId, effort }) => {
+      const requestId = `agent_create_run-${Date.now()}-${Math.random().toString(36).slice(2, 7)}`;
+      const logger = createRequestLogger(requestId, "agent_create_run");
+      logger.start(query.slice(0, 120));
+
+      try {
+        const client = new AgentApiClient(config);
+        const runInput: AgentRunInput = {
+          query,
+          ...(systemPrompt != null ? { systemPrompt } : {}),
+          ...(outputSchema != null ? { outputSchema } : {}),
+          ...(input != null ? { input } : {}),
+          ...(dataSources != null ? { dataSources } : {}),
+          ...(previousRunId != null ? { previousRunId } : {}),
+          effort: (effort ?? "auto") as AgentEffort,
+        };
+
+        checkpoint("agent_create_run_request_prepared", {
+          hasSchema: outputSchema != null,
+          hasInputData: input?.data != null,
+          hasDataSources: dataSources != null,
+          hasPreviousRunId: previousRunId != null,
+          effort: runInput.effort,
+        });
+
+        const run = await client.createRun(runInput);
+        checkpoint("agent_create_run_response_received", { status: run.status });
+        logger.complete();
+
+        return jsonContent({
+          success: true,
+          id: run.id,
+          status: run.status,
+          createdAt: run.createdAt,
+          previousRunId: previousRunId ?? null,
+          nextAction: `Call agent_wait_for_run with runId "${run.id}".`,
+          run,
+        });
+      } catch (error) {
+        logger.error(error);
+        return formatAgentToolError(error, "agent_create_run", config?.userProvidedApiKey);
+      }
+    },
+  );
+}

--- a/src/tools/agentGetRunOutput.ts
+++ b/src/tools/agentGetRunOutput.ts
@@ -7,11 +7,7 @@ import { createRequestLogger } from "../utils/logger.js";
 import { jsonContent } from "../utils/response.js";
 import { isTerminalStatus } from "./runStatus.js";
 
-type AgentToolConfig = AgentApiClientConfig & {
-  userProvidedApiKey?: boolean;
-};
-
-export function registerAgentGetRunOutputTool(server: McpServer, config?: AgentToolConfig): void {
+export function registerAgentGetRunOutputTool(server: McpServer, config?: AgentApiClientConfig): void {
   server.tool(
     "agent_get_run_output",
     "Retrieve completed Exa Agent output in a Claude-friendly shape: text, structured JSON, grounding, usage, and cost. Use after agent_wait_for_run reports completed.",
@@ -68,7 +64,7 @@ export function registerAgentGetRunOutputTool(server: McpServer, config?: AgentT
         });
       } catch (error) {
         logger.error(error);
-        return formatAgentToolError(error, "agent_get_run_output", config?.userProvidedApiKey);
+        return formatAgentToolError(error, "agent_get_run_output");
       }
     },
   );

--- a/src/tools/agentGetRunOutput.ts
+++ b/src/tools/agentGetRunOutput.ts
@@ -1,0 +1,75 @@
+import { z } from "zod";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { checkpoint } from "agnost";
+import { AgentApiClient, type AgentApiClientConfig } from "../utils/agentApiClient.js";
+import { formatAgentToolError } from "../utils/agentErrorHandler.js";
+import { createRequestLogger } from "../utils/logger.js";
+import { jsonContent } from "../utils/response.js";
+import { isTerminalStatus } from "./runStatus.js";
+
+type AgentToolConfig = AgentApiClientConfig & {
+  userProvidedApiKey?: boolean;
+};
+
+export function registerAgentGetRunOutputTool(server: McpServer, config?: AgentToolConfig): void {
+  server.tool(
+    "agent_get_run_output",
+    "Retrieve completed Exa Agent output in a Claude-friendly shape: text, structured JSON, grounding, usage, and cost. Use after agent_wait_for_run reports completed.",
+    {
+      runId: z.string().min(1).describe("The completed agent_run_... ID."),
+      requireCompleted: z.boolean().optional().describe("If true, return a status response until the run is completed. Default true."),
+      includeText: z.boolean().optional().describe("Include output.text. Default true."),
+      includeStructured: z.boolean().optional().describe("Include output.structured. Default true."),
+      includeGrounding: z.boolean().optional().describe("Include output.grounding citations. Default true."),
+      includeUsage: z.boolean().optional().describe("Include usage and costDollars. Default true."),
+    },
+    {
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+    },
+    async ({ runId, requireCompleted, includeText, includeStructured, includeGrounding, includeUsage }) => {
+      const requestId = `agent_get_run_output-${Date.now()}-${Math.random().toString(36).slice(2, 7)}`;
+      const logger = createRequestLogger(requestId, "agent_get_run_output");
+      logger.start(runId);
+
+      try {
+        const run = await new AgentApiClient(config).getRun(runId);
+        checkpoint("agent_get_run_output_response_received", { status: run.status });
+        logger.complete();
+
+        const mustBeCompleted = requireCompleted ?? true;
+        if (mustBeCompleted && run.status !== "completed") {
+          return jsonContent({
+            success: true,
+            id: run.id,
+            status: run.status,
+            terminal: isTerminalStatus(run.status),
+            outputReady: false,
+            nextAction: isTerminalStatus(run.status)
+              ? "This run ended without completed output. Create a corrected run if the task still needs to be completed."
+              : `Run is still ${run.status}. Call agent_wait_for_run with runId "${runId}".`,
+          });
+        }
+
+        const output: Record<string, unknown> = {};
+        if (includeText ?? true) output.text = run.output.text;
+        if (includeStructured ?? true) output.structured = run.output.structured;
+        if (includeGrounding ?? true) output.grounding = run.output.grounding;
+
+        return jsonContent({
+          success: true,
+          id: run.id,
+          status: run.status,
+          outputReady: run.status === "completed",
+          output,
+          ...(includeUsage ?? true ? { usage: run.usage, costDollars: run.costDollars } : {}),
+          nextAction: "Validate coverage, deduplicate structured rows, inspect grounding, and continue with previousRunId if gaps remain.",
+        });
+      } catch (error) {
+        logger.error(error);
+        return formatAgentToolError(error, "agent_get_run_output", config?.userProvidedApiKey);
+      }
+    },
+  );
+}

--- a/src/tools/agentSchemaTemplates.ts
+++ b/src/tools/agentSchemaTemplates.ts
@@ -1,0 +1,29 @@
+export const agentSchemaTemplates = {
+  companyList: {
+    type: "object",
+    properties: {
+      companies: {
+        type: "array",
+        maxItems: 50,
+        items: {
+          type: "object",
+          properties: {
+            companyName: { type: "string" },
+            website: { type: "string", format: "uri" },
+            segment: { type: "string" },
+            whyItQualifies: { type: "string" },
+            evidenceUrl: { type: "string", format: "uri" },
+            confidence: { type: "string", enum: ["low", "medium", "high"] },
+          },
+          required: ["companyName", "website", "whyItQualifies", "evidenceUrl"],
+        },
+      },
+      coverageNotes: { type: "string" },
+      knownGaps: {
+        type: "array",
+        items: { type: "string" },
+      },
+    },
+    required: ["companies", "coverageNotes"],
+  },
+} as const;

--- a/src/tools/agentWaitForRun.ts
+++ b/src/tools/agentWaitForRun.ts
@@ -1,0 +1,110 @@
+import { z } from "zod";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { checkpoint } from "agnost";
+import { API_CONFIG } from "./config.js";
+import type { AgentRun } from "../types.js";
+import { AgentApiClient, type AgentApiClientConfig } from "../utils/agentApiClient.js";
+import { delay, formatAgentToolError } from "../utils/agentErrorHandler.js";
+import { createRequestLogger } from "../utils/logger.js";
+import { clampInteger, jsonContent } from "../utils/response.js";
+import { isTerminalStatus, nextActionForStatus } from "./runStatus.js";
+
+export type AgentRunReader = {
+  getRun(runId: string): Promise<AgentRun>;
+};
+
+export type WaitForRunResult = {
+  run: AgentRun;
+  terminal: boolean;
+  timedOut: boolean;
+};
+
+type AgentToolConfig = AgentApiClientConfig & {
+  userProvidedApiKey?: boolean;
+};
+
+export async function waitForRun(params: {
+  client: AgentRunReader;
+  runId: string;
+  timeoutSeconds: number;
+  pollIntervalMs: number;
+}): Promise<WaitForRunResult> {
+  const deadline = Date.now() + params.timeoutSeconds * 1000;
+  let lastRun = await params.client.getRun(params.runId);
+
+  while (!isTerminalStatus(lastRun.status) && Date.now() < deadline) {
+    const remainingMs = Math.max(0, deadline - Date.now());
+    await delay(Math.min(params.pollIntervalMs, remainingMs));
+    lastRun = await params.client.getRun(params.runId);
+  }
+
+  return {
+    run: lastRun,
+    terminal: isTerminalStatus(lastRun.status),
+    timedOut: !isTerminalStatus(lastRun.status),
+  };
+}
+
+export function registerAgentWaitForRunTool(server: McpServer, config?: AgentToolConfig): void {
+  server.tool(
+    "agent_wait_for_run",
+    "Poll an Exa Agent run until it reaches completed/failed/cancelled or a bounded timeout. This is the ergonomic default after agent_create_run.",
+    {
+      runId: z.string().min(1).describe("The agent_run_... ID returned by agent_create_run."),
+      timeoutSeconds: z.coerce.number().optional().describe("Maximum time to wait in this MCP call. Default 45, max 50. Longer runs are handled by calling this tool again."),
+      pollIntervalMs: z.coerce.number().optional().describe("Polling interval. Default 4000, min 1000."),
+    },
+    {
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+    },
+    async ({ runId, timeoutSeconds, pollIntervalMs }) => {
+      const requestId = `agent_wait_for_run-${Date.now()}-${Math.random().toString(36).slice(2, 7)}`;
+      const logger = createRequestLogger(requestId, "agent_wait_for_run");
+      logger.start(runId);
+
+      const boundedTimeoutSeconds = clampInteger(
+        timeoutSeconds,
+        API_CONFIG.DEFAULT_WAIT_TIMEOUT_SECONDS,
+        1,
+        API_CONFIG.MAX_WAIT_TIMEOUT_SECONDS,
+      );
+      const boundedPollIntervalMs = clampInteger(
+        pollIntervalMs,
+        API_CONFIG.DEFAULT_POLL_INTERVAL_MS,
+        API_CONFIG.MIN_POLL_INTERVAL_MS,
+        boundedTimeoutSeconds * 1000,
+      );
+
+      try {
+        const result = await waitForRun({
+          client: new AgentApiClient(config),
+          runId,
+          timeoutSeconds: boundedTimeoutSeconds,
+          pollIntervalMs: boundedPollIntervalMs,
+        });
+        checkpoint("agent_wait_for_run_complete", {
+          status: result.run.status,
+          timedOut: result.timedOut,
+        });
+        logger.complete();
+
+        return jsonContent({
+          success: true,
+          id: result.run.id,
+          status: result.run.status,
+          terminal: result.terminal,
+          timedOut: result.timedOut,
+          nextAction: result.timedOut
+            ? `Run is still ${result.run.status}. Call agent_wait_for_run again with runId "${runId}".`
+            : nextActionForStatus(result.run.status, runId),
+          run: result.run,
+        });
+      } catch (error) {
+        logger.error(error);
+        return formatAgentToolError(error, "agent_wait_for_run", config?.userProvidedApiKey);
+      }
+    },
+  );
+}

--- a/src/tools/agentWaitForRun.ts
+++ b/src/tools/agentWaitForRun.ts
@@ -19,10 +19,6 @@ export type WaitForRunResult = {
   timedOut: boolean;
 };
 
-type AgentToolConfig = AgentApiClientConfig & {
-  userProvidedApiKey?: boolean;
-};
-
 export async function waitForRun(params: {
   client: AgentRunReader;
   runId: string;
@@ -45,7 +41,7 @@ export async function waitForRun(params: {
   };
 }
 
-export function registerAgentWaitForRunTool(server: McpServer, config?: AgentToolConfig): void {
+export function registerAgentWaitForRunTool(server: McpServer, config?: AgentApiClientConfig): void {
   server.tool(
     "agent_wait_for_run",
     "Poll an Exa Agent run until it reaches completed/failed/cancelled or a bounded timeout. This is the ergonomic default after agent_create_run.",
@@ -103,7 +99,7 @@ export function registerAgentWaitForRunTool(server: McpServer, config?: AgentToo
         });
       } catch (error) {
         logger.error(error);
-        return formatAgentToolError(error, "agent_wait_for_run", config?.userProvidedApiKey);
+        return formatAgentToolError(error, "agent_wait_for_run");
       }
     },
   );

--- a/src/tools/config.ts
+++ b/src/tools/config.ts
@@ -23,10 +23,17 @@ export function integrationHeaders(tool: string, config?: Record<string, unknown
 // Configuration for API
 export const API_CONFIG = {
   BASE_URL: 'https://api.exa.ai',
+  DEFAULT_POLL_INTERVAL_MS: 4000,
+  MIN_POLL_INTERVAL_MS: 1000,
+  DEFAULT_WAIT_TIMEOUT_SECONDS: 45,
+  MAX_WAIT_TIMEOUT_SECONDS: 50,
   ENDPOINTS: {
     SEARCH: '/search',
     RESEARCH: '/research/v1',
-    CONTEXT: '/context'
+    CONTEXT: '/context',
+    RUNS: '/agent/runs',
+    RUN_BY_ID: (id: string) => `/agent/runs/${encodeURIComponent(id)}`,
+    RUN_CANCEL: (id: string) => `/agent/runs/${encodeURIComponent(id)}/cancel`,
   },
   DEFAULT_NUM_RESULTS: 10,
   DEFAULT_MAX_CHARACTERS: 3000

--- a/src/tools/runStatus.ts
+++ b/src/tools/runStatus.ts
@@ -1,0 +1,16 @@
+export function isTerminalStatus(status: string): boolean {
+  return status === "completed" || status === "failed" || status === "cancelled";
+}
+
+export function nextActionForStatus(status: string, runId: string): string {
+  if (status === "completed") {
+    return `Call agent_get_run_output with runId "${runId}" to retrieve text, structured output, grounding, usage, and cost.`;
+  }
+  if (status === "failed") {
+    return "The run failed. Create a corrected run if the issue is clear, or retry agent_get_run_output later if you are waiting on final state propagation.";
+  }
+  if (status === "cancelled") {
+    return "The run was cancelled. Create a new run if the task still needs to be completed.";
+  }
+  return `Call agent_wait_for_run again with runId "${runId}".`;
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -248,3 +248,56 @@ export interface ExaCodeResponse {
   outputTokens?: number;
   traces?: any;
 }
+
+export type AgentStatus = "queued" | "running" | "completed" | "failed" | "cancelled";
+export type AgentEffort = "low" | "medium" | "high" | "xhigh" | "auto";
+export type AgentDataSourceProvider =
+  | "fiber_ai"
+  | "financial_datasets"
+  | "similar_web"
+  | "baselayer"
+  | "affiliate"
+  | "particle_news"
+  | "jinko";
+
+export type AgentRunInput = {
+  query: string;
+  systemPrompt?: string;
+  input?: {
+    data?: Array<Record<string, unknown>>;
+    exclusion?: Array<Record<string, unknown>>;
+  };
+  outputSchema?: Record<string, unknown> | null;
+  effort?: AgentEffort;
+  flags?: string[];
+  previousRunId?: string;
+  dataSources?: Array<{
+    provider: AgentDataSourceProvider;
+  }>;
+};
+
+export type AgentRun = {
+  id: string;
+  object: "agent_run";
+  status: AgentStatus;
+  stopReason: string | null;
+  createdAt: string;
+  completedAt: string | null;
+  request: unknown;
+  output: {
+    text: string;
+    structured: unknown | null;
+    grounding: Array<{
+      field: string;
+      citations: Array<{ url: string; title?: string }>;
+      confidence: string;
+    }>;
+  };
+  usage?: Record<string, unknown>;
+  costDollars?: Record<string, unknown>;
+};
+
+export type ToolContent = {
+  content: Array<{ type: "text"; text: string }>;
+  isError?: true;
+};

--- a/src/utils/agentApiClient.ts
+++ b/src/utils/agentApiClient.ts
@@ -1,0 +1,56 @@
+import axios, { type AxiosInstance } from "axios";
+import { API_CONFIG, integrationHeaders } from "../tools/config.js";
+import type { AgentRun, AgentRunInput } from "../types.js";
+import { retryAgentRequest } from "./agentErrorHandler.js";
+
+export type AgentApiClientConfig = {
+  exaApiKey?: string;
+  exaSource?: string;
+  mcpSessionId?: string;
+  mcpClient?: unknown;
+};
+
+export class AgentApiClient {
+  private readonly client: AxiosInstance;
+
+  constructor(private readonly config: AgentApiClientConfig = {}) {
+    const apiKey = config.exaApiKey ?? process.env.EXA_API_KEY;
+    if (apiKey == null || apiKey.length === 0) {
+      throw new Error("EXA_API_KEY is required. Provide an Exa API key.");
+    }
+
+    this.client = axios.create({
+      baseURL: API_CONFIG.BASE_URL,
+      timeout: 30000,
+      headers: buildAgentHeaders(apiKey, config),
+    });
+  }
+
+  async createRun(input: AgentRunInput): Promise<AgentRun> {
+    const response = await this.client.post<AgentRun>(API_CONFIG.ENDPOINTS.RUNS, input);
+    return response.data;
+  }
+
+  async getRun(runId: string): Promise<AgentRun> {
+    const response = await retryAgentRequest(() =>
+      this.client.get<AgentRun>(API_CONFIG.ENDPOINTS.RUN_BY_ID(runId)),
+    );
+    return response.data;
+  }
+
+  async cancelRun(runId: string): Promise<AgentRun> {
+    const response = await retryAgentRequest(() =>
+      this.client.post<AgentRun>(API_CONFIG.ENDPOINTS.RUN_CANCEL(runId)),
+    );
+    return response.data;
+  }
+}
+
+export function buildAgentHeaders(apiKey: string, config: AgentApiClientConfig = {}): Record<string, string> {
+  return {
+    accept: "application/json",
+    "content-type": "application/json",
+    "x-api-key": apiKey,
+    ...integrationHeaders("agent-mcp", config),
+  };
+}

--- a/src/utils/agentErrorHandler.ts
+++ b/src/utils/agentErrorHandler.ts
@@ -1,7 +1,8 @@
 import axios from "axios";
 import type { ToolContent } from "../types.js";
+import { EXA_API_KEYS_URL, TRANSIENT_STATUS_CODES, delay, retryOnTransient } from "./errorHandler.js";
 
-const TRANSIENT_STATUS_CODES = new Set([500, 502, 503, 504]);
+export { delay };
 
 export function isTransientAgentError(error: unknown): boolean {
   if (!axios.isAxiosError(error)) return false;
@@ -9,39 +10,22 @@ export function isTransientAgentError(error: unknown): boolean {
   return status != null && TRANSIENT_STATUS_CODES.has(status);
 }
 
-export async function retryAgentRequest<T>(
+export function retryAgentRequest<T>(
   fn: () => Promise<T>,
   opts: { maxRetries?: number; baseDelayMs?: number } = {},
 ): Promise<T> {
-  const maxRetries = opts.maxRetries ?? 2;
-  const baseDelayMs = opts.baseDelayMs ?? 1000;
-  let lastError: unknown;
-
-  for (let attempt = 0; attempt <= maxRetries; attempt += 1) {
-    try {
-      return await fn();
-    } catch (error) {
-      lastError = error;
-      if (!isTransientAgentError(error) || attempt === maxRetries) {
-        throw error;
-      }
-      await delay(baseDelayMs * 2 ** attempt);
-    }
-  }
-
-  throw lastError;
+  return retryOnTransient(fn, isTransientAgentError, opts.maxRetries, opts.baseDelayMs);
 }
 
 export function formatAgentToolError(
   error: unknown,
   toolName: string,
-  userProvidedApiKey?: boolean,
 ): ToolContent {
   if (axios.isAxiosError(error)) {
     const status = error.response?.status ?? "unknown";
     const data = error.response?.data;
     const apiMessage = errorMessageFromData(data) ?? error.message;
-    const guidance = guidanceForStatus(status, userProvidedApiKey);
+    const guidance = guidanceForStatus(status);
     return {
       content: [{
         type: "text",
@@ -70,25 +54,18 @@ function errorMessageFromData(data: unknown): string | undefined {
   return JSON.stringify(data);
 }
 
-function guidanceForStatus(status: number | "unknown", userProvidedApiKey?: boolean): string {
+function guidanceForStatus(status: number | "unknown"): string {
   if (status === 400) {
     return "Check the run body and outputSchema. Use a top-level object schema, bound arrays with maxItems when possible, and use input.data for known rows.";
   }
   if (status === 401 || status === 403) {
-    return "Authenticate with an Exa API key. API keys are available at https://dashboard.exa.ai/api-keys.";
+    return `Authenticate with an Exa API key. API keys are available at ${EXA_API_KEYS_URL}.`;
   }
   if (status === 404) {
     return "Run not found or not visible to this API key. Verify the agent_run_... ID and account.";
-  }
-  if (status === 429 && !userProvidedApiKey) {
-    return "You've hit Exa's free MCP rate limit. Use an Exa API key to continue without anonymous limits.";
   }
   if (status === 429) {
     return "Rate or concurrency limit reached. Wait for active runs to finish, poll existing run IDs, or cancel accidental duplicate runs.";
   }
   return "";
-}
-
-export function delay(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms));
 }

--- a/src/utils/agentErrorHandler.ts
+++ b/src/utils/agentErrorHandler.ts
@@ -1,0 +1,94 @@
+import axios from "axios";
+import type { ToolContent } from "../types.js";
+
+const TRANSIENT_STATUS_CODES = new Set([500, 502, 503, 504]);
+
+export function isTransientAgentError(error: unknown): boolean {
+  if (!axios.isAxiosError(error)) return false;
+  const status = error.response?.status;
+  return status != null && TRANSIENT_STATUS_CODES.has(status);
+}
+
+export async function retryAgentRequest<T>(
+  fn: () => Promise<T>,
+  opts: { maxRetries?: number; baseDelayMs?: number } = {},
+): Promise<T> {
+  const maxRetries = opts.maxRetries ?? 2;
+  const baseDelayMs = opts.baseDelayMs ?? 1000;
+  let lastError: unknown;
+
+  for (let attempt = 0; attempt <= maxRetries; attempt += 1) {
+    try {
+      return await fn();
+    } catch (error) {
+      lastError = error;
+      if (!isTransientAgentError(error) || attempt === maxRetries) {
+        throw error;
+      }
+      await delay(baseDelayMs * 2 ** attempt);
+    }
+  }
+
+  throw lastError;
+}
+
+export function formatAgentToolError(
+  error: unknown,
+  toolName: string,
+  userProvidedApiKey?: boolean,
+): ToolContent {
+  if (axios.isAxiosError(error)) {
+    const status = error.response?.status ?? "unknown";
+    const data = error.response?.data;
+    const apiMessage = errorMessageFromData(data) ?? error.message;
+    const guidance = guidanceForStatus(status, userProvidedApiKey);
+    return {
+      content: [{
+        type: "text",
+        text: [`${toolName} error (${status}): ${apiMessage}`, guidance].filter(Boolean).join("\n\n"),
+      }],
+      isError: true,
+    };
+  }
+
+  return {
+    content: [{
+      type: "text",
+      text: `${toolName} error: ${error instanceof Error ? error.message : String(error)}`,
+    }],
+    isError: true,
+  };
+}
+
+function errorMessageFromData(data: unknown): string | undefined {
+  if (data == null || typeof data !== "object") return undefined;
+  const record = data as Record<string, unknown>;
+  const message = record.message;
+  if (typeof message === "string") return message;
+  const error = record.error;
+  if (typeof error === "string") return error;
+  return JSON.stringify(data);
+}
+
+function guidanceForStatus(status: number | "unknown", userProvidedApiKey?: boolean): string {
+  if (status === 400) {
+    return "Check the run body and outputSchema. Use a top-level object schema, bound arrays with maxItems when possible, and use input.data for known rows.";
+  }
+  if (status === 401 || status === 403) {
+    return "Authenticate with an Exa API key. API keys are available at https://dashboard.exa.ai/api-keys.";
+  }
+  if (status === 404) {
+    return "Run not found or not visible to this API key. Verify the agent_run_... ID and account.";
+  }
+  if (status === 429 && !userProvidedApiKey) {
+    return "You've hit Exa's free MCP rate limit. Use an Exa API key to continue without anonymous limits.";
+  }
+  if (status === 429) {
+    return "Rate or concurrency limit reached. Wait for active runs to finish, poll existing run IDs, or cancel accidental duplicate runs.";
+  }
+  return "";
+}
+
+export function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/src/utils/agentSkill.ts
+++ b/src/utils/agentSkill.ts
@@ -1,73 +1,35 @@
-import { readFileSync } from "node:fs";
-import { dirname, join } from "node:path";
+import { existsSync, readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
 function stripFrontmatter(content: string): string {
-  if (!content.startsWith("---")) {
-    return content;
-  }
-
+  if (!content.startsWith("---")) return content;
   const end = content.indexOf("---", 3);
-  if (end === -1) {
-    return content;
-  }
-
-  return content.slice(end + 3).trimStart();
+  return end === -1 ? content : content.slice(end + 3).trimStart();
 }
 
-function getModuleDir(): string | undefined {
-  // ESM build (tsc/Vercel): import.meta.url is a file URL.
-  try {
-    const metaUrl =
-      typeof import.meta !== "undefined" ? import.meta.url : undefined;
-    if (metaUrl) {
-      return dirname(fileURLToPath(metaUrl));
-    }
-  } catch {
-    // import.meta is unavailable or unusable in this build target.
-  }
-
-  // CJS build (esbuild stdio bundle): import.meta.url is undefined, but
-  // Node provides __dirname for .cjs files at runtime.
-  if (typeof __dirname !== "undefined") {
-    return __dirname;
-  }
-
-  return undefined;
+function moduleDir(): string {
+  const dir =
+    typeof import.meta !== "undefined" && import.meta.url
+      ? dirname(fileURLToPath(import.meta.url))
+      : typeof __dirname !== "undefined"
+        ? __dirname
+        : undefined;
+  if (!dir) throw new Error("Cannot locate the Agent Skill file at runtime");
+  return dir;
 }
 
-function resolveSkillPath(): string {
-  const candidates = [join(process.cwd(), "skills/agent/SKILL.md")];
-
-  const moduleDir = getModuleDir();
-  if (moduleDir) {
-    candidates.push(
-      join(moduleDir, "skills/agent/SKILL.md"),
-      join(moduleDir, "../skills/agent/SKILL.md"),
-      join(moduleDir, "../../skills/agent/SKILL.md"),
-      join(moduleDir, "../../../skills/agent/SKILL.md"),
-    );
+function findSkillFile(): string {
+  for (let dir = moduleDir(); ; dir = resolve(dir, "..")) {
+    const skillPath = resolve(dir, "skills", "agent", "SKILL.md");
+    if (existsSync(skillPath)) return skillPath;
+    if (dir === resolve(dir, "..")) throw new Error("Agent Skill file not found");
   }
-
-  for (const candidate of candidates) {
-    try {
-      readFileSync(candidate);
-      return candidate;
-    } catch {
-      continue;
-    }
-  }
-
-  throw new Error("Could not locate skills/agent/SKILL.md");
 }
 
-let cachedSkillContent: string | undefined;
+let cached: string | undefined;
 
 export function loadAgentSkillContent(): string {
-  if (cachedSkillContent) {
-    return cachedSkillContent;
-  }
-
-  cachedSkillContent = stripFrontmatter(readFileSync(resolveSkillPath(), "utf8"));
-  return cachedSkillContent;
+  cached ??= stripFrontmatter(readFileSync(findSkillFile(), "utf8"));
+  return cached;
 }

--- a/src/utils/agentSkill.ts
+++ b/src/utils/agentSkill.ts
@@ -1,0 +1,73 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+function stripFrontmatter(content: string): string {
+  if (!content.startsWith("---")) {
+    return content;
+  }
+
+  const end = content.indexOf("---", 3);
+  if (end === -1) {
+    return content;
+  }
+
+  return content.slice(end + 3).trimStart();
+}
+
+function getModuleDir(): string | undefined {
+  // ESM build (tsc/Vercel): import.meta.url is a file URL.
+  try {
+    const metaUrl =
+      typeof import.meta !== "undefined" ? import.meta.url : undefined;
+    if (metaUrl) {
+      return dirname(fileURLToPath(metaUrl));
+    }
+  } catch {
+    // import.meta is unavailable or unusable in this build target.
+  }
+
+  // CJS build (esbuild stdio bundle): import.meta.url is undefined, but
+  // Node provides __dirname for .cjs files at runtime.
+  if (typeof __dirname !== "undefined") {
+    return __dirname;
+  }
+
+  return undefined;
+}
+
+function resolveSkillPath(): string {
+  const candidates = [join(process.cwd(), "skills/agent/SKILL.md")];
+
+  const moduleDir = getModuleDir();
+  if (moduleDir) {
+    candidates.push(
+      join(moduleDir, "skills/agent/SKILL.md"),
+      join(moduleDir, "../skills/agent/SKILL.md"),
+      join(moduleDir, "../../skills/agent/SKILL.md"),
+      join(moduleDir, "../../../skills/agent/SKILL.md"),
+    );
+  }
+
+  for (const candidate of candidates) {
+    try {
+      readFileSync(candidate);
+      return candidate;
+    } catch {
+      continue;
+    }
+  }
+
+  throw new Error("Could not locate skills/agent/SKILL.md");
+}
+
+let cachedSkillContent: string | undefined;
+
+export function loadAgentSkillContent(): string {
+  if (cachedSkillContent) {
+    return cachedSkillContent;
+  }
+
+  cachedSkillContent = stripFrontmatter(readFileSync(resolveSkillPath(), "utf8"));
+  return cachedSkillContent;
+}

--- a/src/utils/errorHandler.ts
+++ b/src/utils/errorHandler.ts
@@ -6,11 +6,44 @@ import { ExaError } from "exa-js";
 
 type ToolErrorResult = { content: Array<{ type: "text"; text: string }>; isError: true };
 
-const TRANSIENT_STATUS_CODES = new Set([500, 502, 503, 504]);
+export const TRANSIENT_STATUS_CODES = new Set([500, 502, 503, 504]);
 
-const FREE_MCP_RATE_LIMIT_MESSAGE = `You've hit Exa's free MCP rate limit. To continue using without limits, create your own Exa API key.
+export const EXA_API_KEYS_URL = "https://dashboard.exa.ai/api-keys";
 
-Fix: Create API key at https://dashboard.exa.ai/api-keys , and then update Exa MCP URL to this https://mcp.exa.ai/mcp?exaApiKey=YOUR_EXA_API_KEY`;
+export const FREE_MCP_RATE_LIMIT_MESSAGE = `You've hit Exa's free MCP rate limit. To continue using without limits, create your own Exa API key.
+
+Fix: Create API key at ${EXA_API_KEYS_URL} , and then update Exa MCP URL to this https://mcp.exa.ai/mcp?exaApiKey=YOUR_EXA_API_KEY`;
+
+export function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export async function retryOnTransient<T>(
+  fn: () => Promise<T>,
+  isTransient: (error: unknown) => boolean,
+  maxRetries = 2,
+  baseDelayMs = 1000,
+): Promise<T> {
+  let lastError: unknown;
+  for (let attempt = 0; attempt <= maxRetries; attempt++) {
+    try {
+      return await fn();
+    } catch (error) {
+      lastError = error;
+      if (!isTransient(error) || attempt === maxRetries) throw error;
+      await delay(baseDelayMs * 2 ** attempt);
+    }
+  }
+  throw lastError;
+}
+
+function isTransientExaError(error: unknown): boolean {
+  return error instanceof ExaError && TRANSIENT_STATUS_CODES.has(error.statusCode);
+}
+
+export function retryWithBackoff<T>(fn: () => Promise<T>, maxRetries = 2): Promise<T> {
+  return retryOnTransient(fn, isTransientExaError, maxRetries);
+}
 
 /**
  * Checks if an error is a rate limit error (HTTP 429) and if the user is using the free MCP.
@@ -36,29 +69,6 @@ export function handleRateLimitError(
   }
 
   return null;
-}
-
-/**
- * Retries an async function on transient (5xx) errors with exponential backoff.
- * Delays: 1s after first failure, 2s after second failure.
- */
-export async function retryWithBackoff<T>(
-  fn: () => Promise<T>,
-  maxRetries: number = 2
-): Promise<T> {
-  let lastError: unknown;
-  for (let attempt = 0; attempt <= maxRetries; attempt++) {
-    try {
-      return await fn();
-    } catch (error) {
-      lastError = error;
-      if (!(error instanceof ExaError) || !TRANSIENT_STATUS_CODES.has(error.statusCode) || attempt === maxRetries) {
-        throw error;
-      }
-      await new Promise(r => setTimeout(r, 1000 * Math.pow(2, attempt)));
-    }
-  }
-  throw lastError;
 }
 
 /**

--- a/src/utils/response.ts
+++ b/src/utils/response.ts
@@ -1,0 +1,15 @@
+import type { ToolContent } from "../types.js";
+
+export function jsonContent(value: unknown): ToolContent {
+  return {
+    content: [{
+      type: "text",
+      text: JSON.stringify(value, null, 2),
+    }],
+  };
+}
+
+export function clampInteger(value: number | undefined, fallback: number, min: number, max: number): number {
+  if (value == null || !Number.isFinite(value)) return fallback;
+  return Math.max(min, Math.min(max, Math.trunc(value)));
+}

--- a/tests/unit/api/mcp.test.ts
+++ b/tests/unit/api/mcp.test.ts
@@ -430,6 +430,36 @@ describe("api/mcp handler", () => {
     expect(new URL(forwardedRequest?.url ?? "").searchParams.has("exaApiKey")).toBe(false);
   });
 
+  it("expands the agent tool alias from query parameters", async () => {
+    const { config } = await callHandleRequest(
+      new Request("https://mcp.exa.ai/mcp?tools=agent_tools"),
+    );
+
+    expect(config).toMatchObject({
+      enabledTools: [
+        "agent_create_run",
+        "agent_wait_for_run",
+        "agent_get_run_output",
+        "agent_cancel_run",
+      ],
+    });
+  });
+
+  it("expands the agent tool alias from ENABLED_TOOLS", async () => {
+    process.env.ENABLED_TOOLS = "agent_tools";
+
+    const { config } = await callHandleRequest(new Request("https://mcp.exa.ai/mcp"));
+
+    expect(config).toMatchObject({
+      enabledTools: [
+        "agent_create_run",
+        "agent_wait_for_run",
+        "agent_get_run_output",
+        "agent_cancel_run",
+      ],
+    });
+  });
+
   it("accepts instant as a defaultSearchType query parameter", async () => {
     const { config } = await callHandleRequest(
       new Request("https://mcp.exa.ai/mcp?defaultSearchType=instant"),

--- a/tests/unit/mcp-handler.test.ts
+++ b/tests/unit/mcp-handler.test.ts
@@ -38,6 +38,7 @@ describe("initializeMcpServer", () => {
         expect.objectContaining({ id: "web_search_exa", enabled: true }),
         expect.objectContaining({ id: "web_fetch_exa", enabled: true }),
         expect.objectContaining({ id: "web_search_advanced_exa", enabled: false }),
+        expect.objectContaining({ id: "agent_create_run", enabled: false }),
       ]),
     );
   });
@@ -62,5 +63,45 @@ describe("initializeMcpServer", () => {
     });
 
     expect(server.tools.map((tool) => tool.name)).toEqual(["deep_search_exa"]);
+  });
+
+  it("registers opt-in Agent tools, prompt, and schema resource when authenticated", async () => {
+    const server = new FakeMcpServer();
+
+    initializeMcpServer(server, {
+      enabledTools: ["agent_create_run", "agent_wait_for_run", "agent_get_run_output", "agent_cancel_run"],
+      userProvidedApiKey: true,
+    });
+
+    expect(server.tools.map((tool) => tool.name)).toEqual([
+      "agent_create_run",
+      "agent_wait_for_run",
+      "agent_get_run_output",
+      "agent_cancel_run",
+    ]);
+    expect(server.prompts.map((prompt) => prompt.name)).toEqual(["web_search_help"]);
+    expect(server.resources.map((resource) => resource.name)).toEqual(["tools_list"]);
+  });
+
+  it("does not register Agent tools without user-provided auth", async () => {
+    const server = new FakeMcpServer();
+
+    initializeMcpServer(server, {
+      enabledTools: ["agent_create_run", "agent_wait_for_run", "agent_get_run_output", "agent_cancel_run"],
+      userProvidedApiKey: false,
+    });
+
+    expect(server.tools).toEqual([]);
+    expect(server.prompts.map((prompt) => prompt.name)).toEqual(["web_search_help"]);
+    expect(server.resources.map((resource) => resource.name)).toEqual(["tools_list"]);
+
+    const resourceResult = await server.resources[0].handler();
+    const toolsList = JSON.parse((resourceResult as any).contents[0].text);
+    expect(toolsList).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ id: "agent_create_run", enabled: false }),
+        expect.objectContaining({ id: "agent_wait_for_run", enabled: false }),
+      ]),
+    );
   });
 });

--- a/tests/unit/mcp-handler.test.ts
+++ b/tests/unit/mcp-handler.test.ts
@@ -79,8 +79,49 @@ describe("initializeMcpServer", () => {
       "agent_get_run_output",
       "agent_cancel_run",
     ]);
-    expect(server.prompts.map((prompt) => prompt.name)).toEqual(["web_search_help"]);
-    expect(server.resources.map((resource) => resource.name)).toEqual(["tools_list"]);
+    expect(server.prompts.map((prompt) => prompt.name)).toEqual(["web_search_help", "agent_research_help"]);
+    expect(server.resources.map((resource) => resource.name)).toEqual(["tools_list", "agent_research_guide", "agent_schema_templates"]);
+
+    const agentGuide = await server.resources[1].handler();
+    expect(agentGuide).toMatchObject({
+      contents: [
+        {
+          uri: "exa://agent/skill",
+          mimeType: "text/markdown",
+        },
+      ],
+    });
+    expect((agentGuide as any).contents[0].text).toContain("Exa Agent Research");
+    expect((agentGuide as any).contents[0].text).toContain("agent_create_run");
+
+    const agentPrompt = server.prompts.find((prompt) => prompt.name === "agent_research_help");
+    expect(agentPrompt).toBeDefined();
+    const promptResult = await agentPrompt!.handler();
+    expect((promptResult as any).messages).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          role: "user",
+          content: expect.objectContaining({
+            type: "resource",
+            resource: expect.objectContaining({
+              uri: "exa://agent/skill",
+              mimeType: "text/markdown",
+              text: expect.stringContaining("Exa Agent Research"),
+            }),
+          }),
+        }),
+      ]),
+    );
+
+    const schemaTemplates = await server.resources[2].handler();
+    expect(schemaTemplates).toMatchObject({
+      contents: [
+        {
+          uri: "exa://agent/schema-templates",
+          mimeType: "application/json",
+        },
+      ],
+    });
   });
 
   it("does not register Agent tools without user-provided auth", async () => {

--- a/tests/unit/stdio.test.ts
+++ b/tests/unit/stdio.test.ts
@@ -63,6 +63,8 @@ describe("Stdio entrypoint", () => {
       exaApiKey: "env-key",
       enabledTools: ["web_search_exa", "web_fetch_exa"],
       debug: false,
+      exaSource: undefined,
+      mcpSessionId: undefined,
       defaultSearchType: undefined,
       userProvidedApiKey: true,
     });
@@ -81,9 +83,23 @@ describe("Stdio entrypoint", () => {
       exaApiKey: undefined,
       enabledTools: ["web_search_exa"],
       debug: true,
+      exaSource: undefined,
+      mcpSessionId: undefined,
       defaultSearchType: "fast",
       userProvidedApiKey: false,
     });
+  });
+
+  it("buildConfigFromEnv includes optional integration metadata", async () => {
+    const { buildConfigFromEnv } = await import("../../src/stdio.js");
+
+    const config = buildConfigFromEnv({
+      EXA_SOURCE: "local",
+      MCP_SESSION_ID: "session-1",
+    });
+
+    expect(config.exaSource).toBe("local");
+    expect(config.mcpSessionId).toBe("session-1");
   });
 
   it("buildConfigFromEnv accepts instant as a default search type", async () => {

--- a/tests/unit/stdio.test.ts
+++ b/tests/unit/stdio.test.ts
@@ -70,6 +70,21 @@ describe("Stdio entrypoint", () => {
     });
   });
 
+  it("buildConfigFromEnv expands the agent tool alias", async () => {
+    const { buildConfigFromEnv } = await import("../../src/stdio.js");
+
+    const config = buildConfigFromEnv({
+      ENABLED_TOOLS: "agent_tools",
+    });
+
+    expect(config.enabledTools).toEqual([
+      "agent_create_run",
+      "agent_wait_for_run",
+      "agent_get_run_output",
+      "agent_cancel_run",
+    ]);
+  });
+
   it("buildConfigFromEnv leaves userProvidedApiKey false when EXA_API_KEY is missing", async () => {
     const { buildConfigFromEnv } = await import("../../src/stdio.js");
 

--- a/tests/unit/tools/agentWaitForRun.test.ts
+++ b/tests/unit/tools/agentWaitForRun.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+import type { AgentRun } from "../../../src/types.js";
+import { waitForRun, type AgentRunReader } from "../../../src/tools/agentWaitForRun.js";
+
+function run(status: AgentRun["status"]): AgentRun {
+  return {
+    id: "agent_run_test",
+    object: "agent_run",
+    status,
+    stopReason: null,
+    createdAt: "2026-06-12T00:00:00.000Z",
+    completedAt: status === "completed" ? "2026-06-12T00:00:01.000Z" : null,
+    request: {},
+    output: {
+      text: status === "completed" ? "done" : "",
+      structured: status === "completed" ? { items: [] } : null,
+      grounding: [],
+    },
+  };
+}
+
+describe("waitForRun", () => {
+  it("returns immediately for completed runs", async () => {
+    const reader: AgentRunReader = {
+      getRun: async () => run("completed"),
+    };
+
+    const result = await waitForRun({
+      client: reader,
+      runId: "agent_run_test",
+      timeoutSeconds: 1,
+      pollIntervalMs: 1,
+    });
+
+    expect(result.terminal).toBe(true);
+    expect(result.timedOut).toBe(false);
+    expect(result.run.status).toBe("completed");
+  });
+
+  it("reports timedOut when the run is still active at the deadline", async () => {
+    const reader: AgentRunReader = {
+      getRun: async () => run("running"),
+    };
+
+    const result = await waitForRun({
+      client: reader,
+      runId: "agent_run_test",
+      timeoutSeconds: 0,
+      pollIntervalMs: 1,
+    });
+
+    expect(result.terminal).toBe(false);
+    expect(result.timedOut).toBe(true);
+  });
+});

--- a/tests/unit/utils/agentApiClient.test.ts
+++ b/tests/unit/utils/agentApiClient.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import { buildAgentHeaders } from "../../../src/utils/agentApiClient.js";
+
+describe("buildAgentHeaders", () => {
+  it("sets required Agent auth and integration headers", () => {
+    const headers = buildAgentHeaders("exa_test_key", {
+      exaSource: "claude",
+      mcpSessionId: "session-123",
+    });
+
+    expect(headers["x-api-key"]).toBe("exa_test_key");
+    expect(headers["x-exa-integration"]).toBe("agent-mcp:claude");
+    expect(headers["x-exa-mcp-session-id"]).toBe("session-123");
+  });
+
+  it("forwards MCP client metadata through shared header plumbing", () => {
+    const headers = buildAgentHeaders("exa_test_key", {
+      mcpClient: {
+        source: "claude-code",
+        sessionId: "session-123",
+        clientInfo: {
+          name: "Claude Code",
+          version: "1.0.0",
+        },
+      },
+    });
+
+    expect(headers["x-exa-integration"]).toBe("agent-mcp");
+    expect(headers["x-exa-mcp-client"]).toBe(JSON.stringify({
+      source: "claude-code",
+      sessionId: "session-123",
+      clientInfo: {
+        name: "Claude Code",
+        version: "1.0.0",
+      },
+    }));
+  });
+});

--- a/vercel.json
+++ b/vercel.json
@@ -2,11 +2,13 @@
   "functions": {
     "api/mcp.ts": {
       "maxDuration": 60,
-      "memory": 1024
+      "memory": 1024,
+      "includeFiles": "skills/**"
     },
     "api/mcp-oauth.ts": {
       "maxDuration": 60,
-      "memory": 1024
+      "memory": 1024,
+      "includeFiles": "skills/**"
     }
   },
   "rewrites": [
@@ -42,4 +44,3 @@
   "buildCommand": "npm run build:vercel",
   "outputDirectory": "dist"
 }
-


### PR DESCRIPTION
## Summary

Adds Exa Agent support to the MCP server as an optional authenticated toolset.

This includes the Agent run lifecycle tools, an MCP prompt and resource for the Exa Agent guide, packaged skill assets, and documentation updates for enabling the new tools.

## What changed

- add `agent_create_run`, `agent_wait_for_run`, `agent_get_run_output`, and `agent_cancel_run`
- expose Exa Agent through the existing optional tool selection flow
- require OAuth or an API key for Exa Agent tools
- add an Exa Agent guide prompt and resource
- package the Exa Agent skill for npm, Docker, and deployment environments
- document how to enable and use Exa Agent tools

## Validation

- `npm run typecheck`
- `npm test`
