### PR TITLE
Refactor MCP request logging and Agent tool scaffolding

### DIFF
--- a/src/tools/agentCancelRun.ts
+++ b/src/tools/agentCancelRun.ts
@@ -1,9 +1,8 @@
 import { z } from "zod";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { checkpoint } from "agnost";
-import { AgentApiClient, type AgentApiClientConfig } from "../utils/agentApiClient.js";
-import { formatAgentToolError } from "../utils/agentErrorHandler.js";
-import { createRequestLogger } from "../utils/logger.js";
+import type { AgentApiClientConfig } from "../utils/agentApiClient.js";
+import { withAgentTool } from "../utils/agentTool.js";
 import { jsonContent } from "../utils/response.js";
 
 export function registerAgentCancelRunTool(server: McpServer, config?: AgentApiClientConfig): void {
@@ -18,14 +17,13 @@ export function registerAgentCancelRunTool(server: McpServer, config?: AgentApiC
       destructiveHint: false,
       idempotentHint: true,
     },
-    async ({ runId }) => {
-      const logger = createRequestLogger("agent_cancel_run");
-      logger.start(runId);
-
-      try {
-        const run = await new AgentApiClient(config).cancelRun(runId);
+    withAgentTool(
+      "agent_cancel_run",
+      config,
+      ({ runId }) => runId,
+      async ({ runId }, { client }) => {
+        const run = await client.cancelRun(runId);
         checkpoint("agent_cancel_run_response_received", { status: run.status });
-        logger.complete();
 
         return jsonContent({
           success: true,
@@ -34,10 +32,7 @@ export function registerAgentCancelRunTool(server: McpServer, config?: AgentApiC
           nextAction: "Create a corrected run if the task still needs to be completed.",
           run,
         });
-      } catch (error) {
-        logger.error(error);
-        return formatAgentToolError(error, "agent_cancel_run");
-      }
-    },
+      },
+    ),
   );
 }

--- a/src/tools/agentCancelRun.ts
+++ b/src/tools/agentCancelRun.ts
@@ -19,8 +19,7 @@ export function registerAgentCancelRunTool(server: McpServer, config?: AgentApiC
       idempotentHint: true,
     },
     async ({ runId }) => {
-      const requestId = `agent_cancel_run-${Date.now()}-${Math.random().toString(36).slice(2, 7)}`;
-      const logger = createRequestLogger(requestId, "agent_cancel_run");
+      const logger = createRequestLogger("agent_cancel_run");
       logger.start(runId);
 
       try {

--- a/src/tools/agentCreateRun.ts
+++ b/src/tools/agentCreateRun.ts
@@ -43,8 +43,7 @@ export function registerAgentCreateRunTool(server: McpServer, config?: AgentApiC
       idempotentHint: false,
     },
     async ({ query, systemPrompt, outputSchema, input, dataSources, previousRunId, effort }) => {
-      const requestId = `agent_create_run-${Date.now()}-${Math.random().toString(36).slice(2, 7)}`;
-      const logger = createRequestLogger(requestId, "agent_create_run");
+      const logger = createRequestLogger("agent_create_run");
       logger.start(query.slice(0, 120));
 
       try {

--- a/src/tools/agentCreateRun.ts
+++ b/src/tools/agentCreateRun.ts
@@ -2,9 +2,8 @@ import { z } from "zod";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { checkpoint } from "agnost";
 import type { AgentEffort, AgentRunInput } from "../types.js";
-import { AgentApiClient, type AgentApiClientConfig } from "../utils/agentApiClient.js";
-import { formatAgentToolError } from "../utils/agentErrorHandler.js";
-import { createRequestLogger } from "../utils/logger.js";
+import type { AgentApiClientConfig } from "../utils/agentApiClient.js";
+import { withAgentTool } from "../utils/agentTool.js";
 import { jsonContent } from "../utils/response.js";
 
 const effortSchema = z.enum(["low", "medium", "high", "xhigh", "auto"]);
@@ -42,12 +41,11 @@ export function registerAgentCreateRunTool(server: McpServer, config?: AgentApiC
       destructiveHint: false,
       idempotentHint: false,
     },
-    async ({ query, systemPrompt, outputSchema, input, dataSources, previousRunId, effort }) => {
-      const logger = createRequestLogger("agent_create_run");
-      logger.start(query.slice(0, 120));
-
-      try {
-        const client = new AgentApiClient(config);
+    withAgentTool(
+      "agent_create_run",
+      config,
+      ({ query }) => query.slice(0, 120),
+      async ({ query, systemPrompt, outputSchema, input, dataSources, previousRunId, effort }, { client }) => {
         const runInput: AgentRunInput = {
           query,
           ...(systemPrompt != null ? { systemPrompt } : {}),
@@ -68,7 +66,6 @@ export function registerAgentCreateRunTool(server: McpServer, config?: AgentApiC
 
         const run = await client.createRun(runInput);
         checkpoint("agent_create_run_response_received", { status: run.status });
-        logger.complete();
 
         return jsonContent({
           success: true,
@@ -79,10 +76,7 @@ export function registerAgentCreateRunTool(server: McpServer, config?: AgentApiC
           nextAction: `Call agent_wait_for_run with runId "${run.id}".`,
           run,
         });
-      } catch (error) {
-        logger.error(error);
-        return formatAgentToolError(error, "agent_create_run");
-      }
-    },
+      },
+    ),
   );
 }

--- a/src/tools/agentGetRunOutput.ts
+++ b/src/tools/agentGetRunOutput.ts
@@ -25,8 +25,7 @@ export function registerAgentGetRunOutputTool(server: McpServer, config?: AgentA
       idempotentHint: true,
     },
     async ({ runId, requireCompleted, includeText, includeStructured, includeGrounding, includeUsage }) => {
-      const requestId = `agent_get_run_output-${Date.now()}-${Math.random().toString(36).slice(2, 7)}`;
-      const logger = createRequestLogger(requestId, "agent_get_run_output");
+      const logger = createRequestLogger("agent_get_run_output");
       logger.start(runId);
 
       try {

--- a/src/tools/agentGetRunOutput.ts
+++ b/src/tools/agentGetRunOutput.ts
@@ -1,9 +1,8 @@
 import { z } from "zod";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { checkpoint } from "agnost";
-import { AgentApiClient, type AgentApiClientConfig } from "../utils/agentApiClient.js";
-import { formatAgentToolError } from "../utils/agentErrorHandler.js";
-import { createRequestLogger } from "../utils/logger.js";
+import type { AgentApiClientConfig } from "../utils/agentApiClient.js";
+import { withAgentTool } from "../utils/agentTool.js";
 import { jsonContent } from "../utils/response.js";
 import { isTerminalStatus } from "./runStatus.js";
 
@@ -24,14 +23,13 @@ export function registerAgentGetRunOutputTool(server: McpServer, config?: AgentA
       destructiveHint: false,
       idempotentHint: true,
     },
-    async ({ runId, requireCompleted, includeText, includeStructured, includeGrounding, includeUsage }) => {
-      const logger = createRequestLogger("agent_get_run_output");
-      logger.start(runId);
-
-      try {
-        const run = await new AgentApiClient(config).getRun(runId);
+    withAgentTool(
+      "agent_get_run_output",
+      config,
+      ({ runId }) => runId,
+      async ({ runId, requireCompleted, includeText, includeStructured, includeGrounding, includeUsage }, { client }) => {
+        const run = await client.getRun(runId);
         checkpoint("agent_get_run_output_response_received", { status: run.status });
-        logger.complete();
 
         const mustBeCompleted = requireCompleted ?? true;
         if (mustBeCompleted && run.status !== "completed") {
@@ -61,10 +59,7 @@ export function registerAgentGetRunOutputTool(server: McpServer, config?: AgentA
           ...(includeUsage ?? true ? { usage: run.usage, costDollars: run.costDollars } : {}),
           nextAction: "Validate coverage, deduplicate structured rows, inspect grounding, and continue with previousRunId if gaps remain.",
         });
-      } catch (error) {
-        logger.error(error);
-        return formatAgentToolError(error, "agent_get_run_output");
-      }
-    },
+      },
+    ),
   );
 }

--- a/src/tools/agentWaitForRun.ts
+++ b/src/tools/agentWaitForRun.ts
@@ -3,9 +3,9 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { checkpoint } from "agnost";
 import { API_CONFIG } from "./config.js";
 import type { AgentRun } from "../types.js";
-import { AgentApiClient, type AgentApiClientConfig } from "../utils/agentApiClient.js";
-import { delay, formatAgentToolError } from "../utils/agentErrorHandler.js";
-import { createRequestLogger } from "../utils/logger.js";
+import type { AgentApiClientConfig } from "../utils/agentApiClient.js";
+import { delay } from "../utils/agentErrorHandler.js";
+import { withAgentTool } from "../utils/agentTool.js";
 import { clampInteger, jsonContent } from "../utils/response.js";
 import { isTerminalStatus, nextActionForStatus } from "./runStatus.js";
 
@@ -55,26 +55,26 @@ export function registerAgentWaitForRunTool(server: McpServer, config?: AgentApi
       destructiveHint: false,
       idempotentHint: true,
     },
-    async ({ runId, timeoutSeconds, pollIntervalMs }) => {
-      const logger = createRequestLogger("agent_wait_for_run");
-      logger.start(runId);
+    withAgentTool(
+      "agent_wait_for_run",
+      config,
+      ({ runId }) => runId,
+      async ({ runId, timeoutSeconds, pollIntervalMs }, { client }) => {
+        const boundedTimeoutSeconds = clampInteger(
+          timeoutSeconds,
+          API_CONFIG.DEFAULT_WAIT_TIMEOUT_SECONDS,
+          1,
+          API_CONFIG.MAX_WAIT_TIMEOUT_SECONDS,
+        );
+        const boundedPollIntervalMs = clampInteger(
+          pollIntervalMs,
+          API_CONFIG.DEFAULT_POLL_INTERVAL_MS,
+          API_CONFIG.MIN_POLL_INTERVAL_MS,
+          boundedTimeoutSeconds * 1000,
+        );
 
-      const boundedTimeoutSeconds = clampInteger(
-        timeoutSeconds,
-        API_CONFIG.DEFAULT_WAIT_TIMEOUT_SECONDS,
-        1,
-        API_CONFIG.MAX_WAIT_TIMEOUT_SECONDS,
-      );
-      const boundedPollIntervalMs = clampInteger(
-        pollIntervalMs,
-        API_CONFIG.DEFAULT_POLL_INTERVAL_MS,
-        API_CONFIG.MIN_POLL_INTERVAL_MS,
-        boundedTimeoutSeconds * 1000,
-      );
-
-      try {
         const result = await waitForRun({
-          client: new AgentApiClient(config),
+          client,
           runId,
           timeoutSeconds: boundedTimeoutSeconds,
           pollIntervalMs: boundedPollIntervalMs,
@@ -83,7 +83,6 @@ export function registerAgentWaitForRunTool(server: McpServer, config?: AgentApi
           status: result.run.status,
           timedOut: result.timedOut,
         });
-        logger.complete();
 
         return jsonContent({
           success: true,
@@ -96,10 +95,7 @@ export function registerAgentWaitForRunTool(server: McpServer, config?: AgentApi
             : nextActionForStatus(result.run.status, runId),
           run: result.run,
         });
-      } catch (error) {
-        logger.error(error);
-        return formatAgentToolError(error, "agent_wait_for_run");
-      }
-    },
+      },
+    ),
   );
 }

--- a/src/tools/agentWaitForRun.ts
+++ b/src/tools/agentWaitForRun.ts
@@ -56,8 +56,7 @@ export function registerAgentWaitForRunTool(server: McpServer, config?: AgentApi
       idempotentHint: true,
     },
     async ({ runId, timeoutSeconds, pollIntervalMs }) => {
-      const requestId = `agent_wait_for_run-${Date.now()}-${Math.random().toString(36).slice(2, 7)}`;
-      const logger = createRequestLogger(requestId, "agent_wait_for_run");
+      const logger = createRequestLogger("agent_wait_for_run");
       logger.start(runId);
 
       const boundedTimeoutSeconds = clampInteger(

--- a/src/tools/companyResearch.ts
+++ b/src/tools/companyResearch.ts
@@ -26,8 +26,7 @@ Returns: Company information from trusted business sources.`,
       idempotentHint: true
     },
     async ({ companyName, numResults }) => {
-      const requestId = `company_research_exa-${Date.now()}-${Math.random().toString(36).substring(2, 7)}`;
-      const logger = createRequestLogger(requestId, 'company_research_exa');
+      const logger = createRequestLogger('company_research_exa');
       
       logger.start(companyName);
       

--- a/src/tools/deepResearchCheck.ts
+++ b/src/tools/deepResearchCheck.ts
@@ -29,8 +29,7 @@ Important: Keep calling with the same research ID until status is 'completed'.`,
       idempotentHint: true
     },
     async ({ researchId }) => {
-      const requestId = `deep_researcher_check-${Date.now()}-${Math.random().toString(36).substring(2, 7)}`;
-      const logger = createRequestLogger(requestId, 'deep_researcher_check');
+      const logger = createRequestLogger('deep_researcher_check');
       
       logger.start(researchId);
       

--- a/src/tools/deepResearchStart.ts
+++ b/src/tools/deepResearchStart.ts
@@ -27,8 +27,7 @@ Important: Call deep_researcher_check with the returned research ID to get the r
       idempotentHint: false
     },
     async ({ instructions, model, outputSchema }) => {
-      const requestId = `deep_researcher_start-${Date.now()}-${Math.random().toString(36).substring(2, 7)}`;
-      const logger = createRequestLogger(requestId, 'deep_researcher_start');
+      const logger = createRequestLogger('deep_researcher_start');
       
       logger.start(instructions);
       

--- a/src/tools/deepSearch.ts
+++ b/src/tools/deepSearch.ts
@@ -33,8 +33,7 @@ Note: Requires an Exa API key. 'deep' mode takes 4-12s, 'deep-reasoning' takes 1
       idempotentHint: false
     },
     async ({ objective, search_queries, type, numResults, highlightMaxCharacters, outputSchema, systemPrompt, structuredOutput }) => {
-      const requestId = `deep_search_exa-${Date.now()}-${Math.random().toString(36).substring(2, 7)}`;
-      const logger = createRequestLogger(requestId, 'deep_search_exa');
+      const logger = createRequestLogger('deep_search_exa');
 
       logger.start(objective);
 

--- a/src/tools/exaCode.ts
+++ b/src/tools/exaCode.ts
@@ -29,8 +29,7 @@ If highlights are insufficient, follow up with web_fetch_exa on the best URLs.`,
       idempotentHint: true
     },
     async ({ query, numResults }) => {
-      const requestId = `get_code_context_exa-${Date.now()}-${Math.random().toString(36).substring(2, 7)}`;
-      const logger = createRequestLogger(requestId, 'get_code_context_exa');
+      const logger = createRequestLogger('get_code_context_exa');
 
       logger.start(`Searching for code context: ${query}`);
 

--- a/src/tools/linkedInSearch.ts
+++ b/src/tools/linkedInSearch.ts
@@ -23,8 +23,7 @@ export function registerLinkedInSearchTool(server: McpServer, config?: { exaApiK
       idempotentHint: true
     },
     async ({ query, numResults }) => {
-      const requestId = `linkedin_search_exa-${Date.now()}-${Math.random().toString(36).substring(2, 7)}`;
-      const logger = createRequestLogger(requestId, 'linkedin_search_exa');
+      const logger = createRequestLogger('linkedin_search_exa');
       
       logger.start(`${query}`);
       

--- a/src/tools/peopleSearch.ts
+++ b/src/tools/peopleSearch.ts
@@ -26,8 +26,7 @@ Returns: Profile information and links.`,
       idempotentHint: true
     },
     async ({ query, numResults }) => {
-      const requestId = `people_search_exa-${Date.now()}-${Math.random().toString(36).substring(2, 7)}`;
-      const logger = createRequestLogger(requestId, 'people_search_exa');
+      const logger = createRequestLogger('people_search_exa');
       
       logger.start(`${query}`);
       

--- a/src/tools/webFetch.ts
+++ b/src/tools/webFetch.ts
@@ -58,8 +58,7 @@ Returns: Clean text content and metadata from the page(s).`,
       idempotentHint: true
     },
     async ({ urls, maxCharacters }) => {
-      const requestId = `web_fetch_exa-${Date.now()}-${Math.random().toString(36).substring(2, 7)}`;
-      const logger = createRequestLogger(requestId, 'web_fetch_exa');
+      const logger = createRequestLogger('web_fetch_exa');
 
       logger.start(urls.join(', '));
 

--- a/src/tools/webSearch.ts
+++ b/src/tools/webSearch.ts
@@ -41,8 +41,7 @@ export function registerWebSearchTool(server: McpServer, config?: WebSearchConfi
     },
     async ({ query, numResults }) => {
       const toolId = toolName || 'web_search_exa';
-      const requestId = `${toolId}-${Date.now()}-${Math.random().toString(36).substring(2, 7)}`;
-      const logger = createRequestLogger(requestId, toolId);
+      const logger = createRequestLogger(toolId);
 
       // Extract category:<type> from query string if present
       const categoryMatch = query.match(/\bcategory:(company|research\s*paper|news|personal\s*site|people)\b/i);

--- a/src/tools/webSearchAdvanced.ts
+++ b/src/tools/webSearchAdvanced.ts
@@ -66,8 +66,7 @@ Returns: Search results with optional highlights, summaries, and subpage content
       idempotentHint: true
     },
     async (params) => {
-      const requestId = `web_search_advanced_exa-${Date.now()}-${Math.random().toString(36).substring(2, 7)}`;
-      const logger = createRequestLogger(requestId, 'web_search_advanced_exa');
+      const logger = createRequestLogger('web_search_advanced_exa');
 
       logger.start(params.query);
 

--- a/src/utils/agentTool.ts
+++ b/src/utils/agentTool.ts
@@ -1,0 +1,32 @@
+import type { ToolContent } from "../types.js";
+import { formatAgentToolError } from "./agentErrorHandler.js";
+import { AgentApiClient, type AgentApiClientConfig } from "./agentApiClient.js";
+import { createRequestLogger } from "./logger.js";
+
+type AgentToolContext = {
+  client: AgentApiClient;
+  logger: ReturnType<typeof createRequestLogger>;
+};
+
+export function withAgentTool<TArgs>(
+  toolName: string,
+  config: AgentApiClientConfig | undefined,
+  startMessage: (args: TArgs) => string,
+  run: (args: TArgs, context: AgentToolContext) => Promise<ToolContent>,
+): (args: TArgs) => Promise<ToolContent> {
+  return async (args: TArgs) => {
+    const requestId = `${toolName}-${Date.now()}-${Math.random().toString(36).slice(2, 7)}`;
+    const logger = createRequestLogger(requestId, toolName);
+    logger.start(startMessage(args));
+
+    try {
+      const client = new AgentApiClient(config);
+      const result = await run(args, { client, logger });
+      logger.complete();
+      return result;
+    } catch (error) {
+      logger.error(error);
+      return formatAgentToolError(error, toolName);
+    }
+  };
+}

--- a/src/utils/agentTool.ts
+++ b/src/utils/agentTool.ts
@@ -15,8 +15,7 @@ export function withAgentTool<TArgs>(
   run: (args: TArgs, context: AgentToolContext) => Promise<ToolContent>,
 ): (args: TArgs) => Promise<ToolContent> {
   return async (args: TArgs) => {
-    const requestId = `${toolName}-${Date.now()}-${Math.random().toString(36).slice(2, 7)}`;
-    const logger = createRequestLogger(requestId, toolName);
+    const logger = createRequestLogger(toolName);
     logger.start(startMessage(args));
 
     try {

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -5,7 +5,8 @@ export const log = (message: string): void => {
   console.error(`[EXA-MCP-DEBUG] ${message}`);
 };
 
-export const createRequestLogger = (requestId: string, toolName: string) => {
+export const createRequestLogger = (toolName: string) => {
+  const requestId = `${toolName}-${Date.now()}-${Math.random().toString(36).slice(2, 7)}`;
   return {
     log: (message: string): void => {
       log(`[${requestId}] [${toolName}] ${message}`);


### PR DESCRIPTION
## Summary

Cleans up shared MCP utility code used by Exa Agent and search tools.

This stacked refactor centralizes request ID generation in `createRequestLogger()` and reduces repeated scaffolding across the Exa Agent tool handlers.

## What changed

- move request ID generation into `createRequestLogger()`
- remove per-tool request ID construction from MCP tool handlers
- align request ID formatting across Agent and search tool implementations
- add a shared `withAgentTool(...)` wrapper for the Exa Agent tool handlers
- reduce repeated logger/client/error-handling scaffolding across the four Agent tools

## Validation

- `npm run typecheck`
- `npm test`
