### PR TITLE
docs: add Autohand Code MCP setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,16 @@ claude mcp add --transport http exa https://mcp.exa.ai/mcp
 </details>
 
 <details>
+<summary><b>Autohand Code</b></summary>
+
+```bash
+autohand mcp add --transport http exa https://mcp.exa.ai/mcp
+```
+
+Add `--scope project` after `add` to keep the server configuration in the current project. See [Autohand Code](https://github.com/autohandai/code-cli/) for current installation and CLI details.
+</details>
+
+<details>
 <summary><b>Claude Desktop</b></summary>
 
 Exa is available as a native Claude Connector — no config files or terminal commands needed.


### PR DESCRIPTION
## What changed

Adds Autohand Code to Exa's client installation list using the hosted `https://mcp.exa.ai/mcp` endpoint already documented throughout the README.

The example uses Autohand Code's HTTP transport and includes the project-scoped option.

## Verification

- Checked the HTTP command against the current Autohand Code MCP CLI
- Ran `git diff --check`

This is a documentation-only change.
