### PR TITLE
fix: add ?login OAuth challenge for Connector distribution (#378)

### DIFF
--- a/README.md
+++ b/README.md
@@ -348,6 +348,20 @@ If you want both search and Exa Agent tools enabled:
 https://mcp.exa.ai/mcp?tools=web_search_exa,web_fetch_exa,agent_tools
 ```
 
+### Force OAuth login (Connectors / Skills / Plugins)
+
+Plain `https://mcp.exa.ai/mcp` stays **keyless free-tier** so first-time explorers can try Exa without an account.
+
+When you distribute a Connector, Skill, or Plugin and need each end user to authenticate with **their own** Exa account (no shared API key in the URL), opt into an OAuth challenge:
+
+```
+https://mcp.exa.ai/mcp?login
+```
+
+Unauthenticated requests to that URL return **HTTP 401** with a `WWW-Authenticate` header pointing at Exa's OAuth protected-resource metadata, so MCP clients (Claude Desktop, etc.) can start the login flow. Equivalent forms: `?login=true`, `?login=1`. You can also use the dedicated endpoint `https://mcp.exa.ai/mcp/oauth`.
+
+Do **not** ship Skills/Plugins with a hardcoded `exaApiKey` in the URL.
+
 ## Agent Skills (Claude Skills)
 
 Ready-to-use skills for Claude Code. Each skill teaches Claude how to use Exa search for a specific task. Copy the content inside a dropdown and paste it into Claude Code — it handles the rest.

--- a/README.md
+++ b/README.md
@@ -348,19 +348,26 @@ If you want both search and Exa Agent tools enabled:
 https://mcp.exa.ai/mcp?tools=web_search_exa,web_fetch_exa,agent_tools
 ```
 
-### Force OAuth login (Connectors / Skills / Plugins)
+### Force OAuth login
 
-Plain `https://mcp.exa.ai/mcp` stays **keyless free-tier** so first-time explorers can try Exa without an account.
-
-When you distribute a Connector, Skill, or Plugin and need each end user to authenticate with **their own** Exa account (no shared API key in the URL), opt into an OAuth challenge:
+To force the OAuth handshake so users sign in with their own Exa account (useful for shared Connectors, Skills, and Plugins), add the `login` parameter:
 
 ```
 https://mcp.exa.ai/mcp?login
 ```
 
-Unauthenticated requests to that URL return **HTTP 401** with a `WWW-Authenticate` header pointing at Exa's OAuth protected-resource metadata, so MCP clients (Claude Desktop, etc.) can start the login flow. Equivalent forms: `?login=true`, `?login=1`. You can also use the dedicated endpoint `https://mcp.exa.ai/mcp/oauth`.
+Or use the `/mcp/oauth` endpoint:
 
-Do **not** ship Skills/Plugins with a hardcoded `exaApiKey` in the URL.
+```
+https://mcp.exa.ai/mcp/oauth
+```
+
+Both can be combined with the `tools` parameter:
+
+```
+https://mcp.exa.ai/mcp?tools=web_search_exa,web_fetch_exa,agent_tools&login
+https://mcp.exa.ai/mcp/oauth?tools=web_search_exa,web_fetch_exa,agent_tools
+```
 
 ## Agent Skills (Claude Skills)
 

--- a/api/mcp.ts
+++ b/api/mcp.ts
@@ -617,8 +617,17 @@ async function processRequest(request: Request, options?: { forceOAuth?: boolean
   const requestUrl = new URL(request.url);
   const isPluginClient = requestUrl.searchParams.get('client')?.includes('plugin') ?? false;
 
-  // Gate: require auth for /mcp/oauth endpoint, matching user agents, or plugin clients (unless bypassed)
-  const requireOAuth = options?.forceOAuth || userAgentMatchesOAuth || isPluginClient;
+  // HuggingFace-style ?login — force OAuth challenge so Connectors / Skills / Plugins can
+  // trigger client auth discovery without hard-coding API keys (see issue #378).
+  // Presence of login (or login=true|1|yes) opts into auth-required mode; free-tier
+  // remains the default for plain https://mcp.exa.ai/mcp.
+  const loginParam = requestUrl.searchParams.get('login');
+  const wantsLogin =
+    requestUrl.searchParams.has('login') &&
+    (loginParam === '' || ['1', 'true', 'yes'].includes(loginParam.toLowerCase()));
+
+  // Gate: require auth for /mcp/oauth, ?login, matching user agents, or plugin clients (unless bypassed)
+  const requireOAuth = options?.forceOAuth || userAgentMatchesOAuth || isPluginClient || wantsLogin;
   if (!bypassRateLimit && requireOAuth && !hasAuth(request)) {
     return create401Response();
   }

--- a/api/mcp.ts
+++ b/api/mcp.ts
@@ -617,13 +617,9 @@ async function processRequest(request: Request, options?: { forceOAuth?: boolean
   const requestUrl = new URL(request.url);
   const isPluginClient = requestUrl.searchParams.get('client')?.includes('plugin') ?? false;
 
-  // HuggingFace-style ?login — force OAuth challenge so Connectors / Skills / Plugins can
-  // trigger client auth discovery without hard-coding API keys (see issue #378).
-  // Presence of login (or login=true|1|yes) opts into auth-required mode; free-tier
-  // remains the default for plain https://mcp.exa.ai/mcp.
   const loginParam = requestUrl.searchParams.get('login');
   const wantsLogin =
-    requestUrl.searchParams.has('login') &&
+    loginParam !== null &&
     (loginParam === '' || ['1', 'true', 'yes'].includes(loginParam.toLowerCase()));
 
   // Gate: require auth for the dedicated /mcp/oauth endpoint, ?login opt-in,

--- a/api/mcp.ts
+++ b/api/mcp.ts
@@ -626,7 +626,8 @@ async function processRequest(request: Request, options?: { forceOAuth?: boolean
     requestUrl.searchParams.has('login') &&
     (loginParam === '' || ['1', 'true', 'yes'].includes(loginParam.toLowerCase()));
 
-  // Gate: require auth for /mcp/oauth, ?login, matching user agents, or plugin clients (unless bypassed)
+  // Gate: require auth for the dedicated /mcp/oauth endpoint, ?login opt-in,
+  // matching user agents, or plugin clients (unless bypassed).
   const requireOAuth = options?.forceOAuth || userAgentMatchesOAuth || isPluginClient || wantsLogin;
   if (!bypassRateLimit && requireOAuth && !hasAuth(request)) {
     return create401Response();

--- a/tests/unit/api/mcp.test.ts
+++ b/tests/unit/api/mcp.test.ts
@@ -609,6 +609,68 @@ describe("api/mcp handler", () => {
     expect(initializeMcpServerMock).not.toHaveBeenCalled();
   });
 
+  it("returns 401 with WWW-Authenticate when ?login is set and no credentials are present (#378)", async () => {
+    const { response, config } = await callHandleRequest(
+      new Request("https://mcp.exa.ai/mcp?login&tools=web_search_exa"),
+    );
+
+    expect(response.status).toBe(401);
+    expect(response.headers.get("WWW-Authenticate")).toContain(
+      'resource_metadata="https://mcp.exa.ai/.well-known/oauth-protected-resource/mcp"',
+    );
+    await expect(response.json()).resolves.toMatchObject({
+      jsonrpc: "2.0",
+      error: {
+        code: -32000,
+        message: "Authentication required. Use OAuth or provide an API key.",
+      },
+      id: null,
+    });
+    expectMcpCorsHeaders(response);
+    expect(config).toBeUndefined();
+    expect(createMcpHandlerMock).not.toHaveBeenCalled();
+    expect(initializeMcpServerMock).not.toHaveBeenCalled();
+  });
+
+  it("accepts ?login=true as an explicit OAuth challenge opt-in", async () => {
+    const { response } = await callHandleRequest(new Request("https://mcp.exa.ai/mcp?login=true"));
+
+    expect(response.status).toBe(401);
+    expect(response.headers.get("WWW-Authenticate")).toContain("resource_metadata=");
+    expect(createMcpHandlerMock).not.toHaveBeenCalled();
+  });
+
+  it("does not force OAuth when login=false so free-tier remains available", async () => {
+    const { response, config } = await callHandleRequest(
+      new Request("https://mcp.exa.ai/mcp?login=false&tools=web_search_exa"),
+    );
+
+    expect(response.status).toBe(200);
+    expect(config).toMatchObject({
+      authMethod: "free_tier",
+      userProvidedApiKey: false,
+    });
+    expect(initializeMcpServerMock).toHaveBeenCalled();
+  });
+
+  it("allows authenticated requests through when ?login is set", async () => {
+    const { response, config } = await callHandleRequest(
+      new Request("https://mcp.exa.ai/mcp?login=true", {
+        headers: {
+          "x-api-key": "user-key",
+        },
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(config).toMatchObject({
+      exaApiKey: "user-key",
+      userProvidedApiKey: true,
+      authMethod: "api_key",
+    });
+    expect(initializeMcpServerMock).toHaveBeenCalled();
+  });
+
   it("uses the internal bypass API key without treating it as user-provided", async () => {
     process.env.RATE_LIMIT_BYPASS = "BypassClient";
     process.env.EXA_API_KEY_BYPASS = "bypass-key";


### PR DESCRIPTION
## Problem

MCP clients that support OAuth discovery (Claude Desktop Connectors, Skills, Plugins) need an unauthenticated request to return **HTTP 401** with `WWW-Authenticate` so they can start the login flow ([MCP auth discovery](https://modelcontextprotocol.io/specification/2025-11-25/basic/authorization#authorization-server-discovery-sequence-diagram)).

Plain `https://mcp.exa.ai/mcp` currently treats missing credentials as **free-tier**, so clients never challenge for OAuth. Distributors then hard-code `exaApiKey` in URLs — unsafe for team/public Skills.

HuggingFace documented the same failure mode and fixed it with a `?login` opt-in: https://huggingface.co/blog/building-hf-mcp#production-deployment

Fixes #378 (short-term HF-style path requested in the issue).

## Repro

```bash
# Before: unauthenticated ?login still behaves as free-tier (no OAuth challenge)
curl -sI 'https://mcp.exa.ai/mcp?login' | head -5
```

## Fix

- Opt into the existing `requireOAuth` gate via `?login` / `?login=true|1|yes`
- Reuse `create401Response()` + protected-resource metadata (same as `/mcp/oauth` and plugin clients)
- Keep default free-tier on plain `/mcp`; `?login=false` does not force auth
- Document Connector/Skill distribution guidance in README

## Verify

```bash
npm test -- tests/unit/api/mcp.test.ts
```

New coverage: unauthenticated `?login` → 401 + `WWW-Authenticate`; `?login=false` → free-tier; authenticated `?login=true` → 200.