### PR TITLE
test: pass request to OAuth metadata handler

### DIFF
--- a/tests/unit/api/mcp.test.ts
+++ b/tests/unit/api/mcp.test.ts
@@ -878,7 +878,9 @@ describe("api/mcp handler", () => {
   it("serves OAuth protected resource metadata for the MCP resource", async () => {
     const { GET } = await import("../../../api/well-known-oauth-protected-resource.js");
 
-    const response = GET();
+    const response = GET(
+      new Request("https://mcp.exa.ai/.well-known/oauth-protected-resource/mcp"),
+    );
 
     expect(response.status).toBe(200);
     await expect(response.json()).resolves.toEqual({


### PR DESCRIPTION
## Summary

Pass the protected-resource metadata request into its GET handler in the unit test.

## Why

The handler now requires a Request to resolve the resource path, but the existing test still called it without arguments, causing CI typechecking to fail with TS2554. This restores CI without changing runtime behavior.

## Validation

- `npm run ci`
- 11 test files passed
- 148 tests passed