### PR TITLE
fix: make OAuth opt-in so API-key clients aren't forced into discovery flow

### DIFF
--- a/api/mcp.ts
+++ b/api/mcp.ts
@@ -564,14 +564,16 @@ function hasAuth(request: Request): boolean {
  *                      client can distinguish "refresh/re-auth" from "start over from scratch" and trigger its
  *                      refresh-token exchange against the authorization server.
  */
-function create401Response(reason: 'missing' | 'invalid_token' = 'missing', resourcePath: string = 'mcp'): Response {
+function create401Response(reason: 'missing' | 'invalid_token' = 'missing', resourcePath: string = 'mcp/oauth'): Response {
   const params: string[] = [];
   if (reason === 'invalid_token') {
     params.push('error="invalid_token"');
     params.push('error_description="The access token is invalid or expired"');
   }
-  // RFC 9728: metadata lives at /.well-known/oauth-protected-resource/<resource path>,
-  // and its `resource` field must exactly match the URL the client connected to.
+  // RFC 9728: metadata lives at /.well-known/oauth-protected-resource/<resource path>.
+  // We always point at the `mcp/oauth` resource (the only one whose metadata is
+  // served), so the client discovers the authorization server even when it was
+  // challenged on the default `/mcp` endpoint.
   params.push(`resource_metadata="https://mcp.exa.ai/.well-known/oauth-protected-resource/${resourcePath}"`);
 
   const message =
@@ -648,7 +650,14 @@ async function processRequest(request: Request, options?: { forceOAuth?: boolean
   // Gate: require auth for the dedicated /mcp/oauth endpoint, ?login opt-in,
   // matching user agents, or plugin clients (unless bypassed).
   const requireOAuth = options?.forceOAuth || userAgentMatchesOAuth || isPluginClient || wantsLogin;
-  const resourcePath = options?.resourcePath ?? 'mcp';
+  // OAuth is anchored on the dedicated `mcp/oauth` resource — the only resource
+  // whose protected-resource metadata is served (see
+  // well-known-oauth-protected-resource.ts). Every OAuth challenge, including the
+  // ones raised on the default `/mcp` endpoint (?login, plugin clients, matching
+  // user agents, missing key for a key-gated tool, expired JWT), must point there
+  // so the client can discover the authorization server; the default `/mcp`
+  // resource intentionally advertises no OAuth.
+  const resourcePath = options?.resourcePath ?? 'mcp/oauth';
   if (!bypassRateLimit && requireOAuth && !hasAuth(request)) {
     return create401Response('missing', resourcePath);
   }

--- a/api/well-known-oauth-protected-resource.ts
+++ b/api/well-known-oauth-protected-resource.ts
@@ -1,6 +1,6 @@
 /**
  * OAuth Protected Resource Metadata (RFC 9728)
- * 
+ *
  * Tells MCP clients where to find the authorization server
  * for this resource server (mcp.exa.ai).
  */
@@ -8,21 +8,58 @@
 const OAUTH_ISSUER = process.env.OAUTH_ISSUER || 'https://auth.exa.ai';
 
 /**
+ * The only resource that participates in OAuth.
+ *
+ * OAuth is strictly opt-in via the dedicated `/mcp/oauth` endpoint. The default
+ * `/mcp` resource is API-key / free-tier only and must NOT be advertised as
+ * OAuth-protected: OAuth-capable MCP clients (Claude, Cursor, VS Code, ChatGPT
+ * connectors) probe this endpoint (RFC 9728) as soon as a server URL is added —
+ * before sending any MCP request and without carrying the `?exaApiKey=` query
+ * param or `x-api-key`/`Authorization` header — so advertising OAuth for `/mcp`
+ * makes them launch an OAuth flow even when the user embedded an API key in the
+ * URL or a header. Only the `mcp/oauth` resource is advertised, so a client
+ * pointed at `/mcp` discovers no authorization server and falls straight through
+ * to the API key / free tier.
+ */
+const OAUTH_RESOURCE_PATH = 'mcp/oauth';
+
+const CORS_HEADERS: Record<string, string> = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Methods': 'GET, OPTIONS',
+  'Access-Control-Allow-Headers': 'Content-Type, Authorization',
+};
+
+/**
  * Resolve which resource this metadata request is for.
  *
  * RFC 9728 clients request /.well-known/oauth-protected-resource/<resource path>
  * and require the returned `resource` to exactly match the URL they connected to.
  * The vercel.json rewrite passes that path suffix along as ?path=..., so echo it
- * back; requests without a path describe the default /mcp resource.
+ * back — but only for the OAuth-enabled resource; every other path (including the
+ * default /mcp resource and the bare, path-less request) resolves to null so the
+ * endpoint 404s instead of advertising OAuth.
  */
-function resolveResource(request: Request): string {
+function resolveResource(request: Request): string | null {
   const path = new URL(request.url).searchParams.get('path');
-  return path ? `https://mcp.exa.ai/${path}` : 'https://mcp.exa.ai/mcp';
+  return path === OAUTH_RESOURCE_PATH ? `https://mcp.exa.ai/${path}` : null;
 }
 
 export function GET(request: Request): Response {
+  const resource = resolveResource(request);
+  if (!resource) {
+    // Not an OAuth-protected resource — 404 so clients fall back to the API key
+    // / free tier instead of initiating an OAuth flow.
+    return new Response(null, {
+      status: 404,
+      headers: {
+        ...CORS_HEADERS,
+        'Cache-Control': 'public, max-age=3600',
+      },
+    });
+  }
+
   const metadata = {
-    resource: resolveResource(request),
+    resource,
     authorization_servers: [OAUTH_ISSUER],
     scopes_supported: ['mcp:tools'],
     bearer_methods_supported: ['header'],
@@ -32,9 +69,7 @@ export function GET(request: Request): Response {
     status: 200,
     headers: {
       'Content-Type': 'application/json',
-      'Access-Control-Allow-Origin': '*',
-      'Access-Control-Allow-Methods': 'GET, OPTIONS',
-      'Access-Control-Allow-Headers': 'Content-Type, Authorization',
+      ...CORS_HEADERS,
       'Cache-Control': 'public, max-age=3600',
     },
   });
@@ -43,10 +78,6 @@ export function GET(request: Request): Response {
 export function OPTIONS(): Response {
   return new Response(null, {
     status: 204,
-    headers: {
-      'Access-Control-Allow-Origin': '*',
-      'Access-Control-Allow-Methods': 'GET, OPTIONS',
-      'Access-Control-Allow-Headers': 'Content-Type, Authorization',
-    },
+    headers: CORS_HEADERS,
   });
 }

--- a/tests/unit/api/mcp.test.ts
+++ b/tests/unit/api/mcp.test.ts
@@ -412,7 +412,7 @@ describe("api/mcp handler", () => {
     expect(wwwAuthenticate).toContain('error="invalid_token"');
     expect(wwwAuthenticate).toContain('error_description="The access token is invalid or expired"');
     expect(wwwAuthenticate).toContain(
-      'resource_metadata="https://mcp.exa.ai/.well-known/oauth-protected-resource/mcp"',
+      'resource_metadata="https://mcp.exa.ai/.well-known/oauth-protected-resource/mcp/oauth"',
     );
     expectMcpCorsHeaders(response);
     expect(config).toBeUndefined();
@@ -435,7 +435,7 @@ describe("api/mcp handler", () => {
     const wwwAuthenticate = response.headers.get("WWW-Authenticate");
     expect(wwwAuthenticate).toContain('error="invalid_token"');
     expect(wwwAuthenticate).toContain(
-      'resource_metadata="https://mcp.exa.ai/.well-known/oauth-protected-resource/mcp"',
+      'resource_metadata="https://mcp.exa.ai/.well-known/oauth-protected-resource/mcp/oauth"',
     );
     expectMcpCorsHeaders(response);
     expect(initializeMcpServerMock).not.toHaveBeenCalled();
@@ -526,7 +526,7 @@ describe("api/mcp handler", () => {
 
     expect(response.status).toBe(401);
     expect(response.headers.get("WWW-Authenticate")).toContain(
-      'resource_metadata="https://mcp.exa.ai/.well-known/oauth-protected-resource/mcp"',
+      'resource_metadata="https://mcp.exa.ai/.well-known/oauth-protected-resource/mcp/oauth"',
     );
     await expect(response.json()).resolves.toMatchObject({
       jsonrpc: "2.0",
@@ -549,7 +549,7 @@ describe("api/mcp handler", () => {
 
     expect(response.status).toBe(401);
     expect(response.headers.get("WWW-Authenticate")).toContain(
-      'resource_metadata="https://mcp.exa.ai/.well-known/oauth-protected-resource/mcp"',
+      'resource_metadata="https://mcp.exa.ai/.well-known/oauth-protected-resource/mcp/oauth"',
     );
     expectMcpCorsHeaders(response);
     expect(config).toBeUndefined();
@@ -620,7 +620,7 @@ describe("api/mcp handler", () => {
 
     expect(response.status).toBe(401);
     expect(response.headers.get("WWW-Authenticate")).toContain(
-      'resource_metadata="https://mcp.exa.ai/.well-known/oauth-protected-resource/mcp"',
+      'resource_metadata="https://mcp.exa.ai/.well-known/oauth-protected-resource/mcp/oauth"',
     );
     await expect(response.json()).resolves.toMatchObject({
       jsonrpc: "2.0",
@@ -745,7 +745,7 @@ describe("api/mcp handler", () => {
 
     expect(response.status).toBe(401);
     expect(response.headers.get("WWW-Authenticate")).toContain(
-      'resource_metadata="https://mcp.exa.ai/.well-known/oauth-protected-resource/mcp"',
+      'resource_metadata="https://mcp.exa.ai/.well-known/oauth-protected-resource/mcp/oauth"',
     );
     expectMcpCorsHeaders(response);
   });
@@ -868,7 +868,7 @@ describe("api/mcp handler", () => {
 
     expect(response.status).toBe(401);
     expect(response.headers.get("WWW-Authenticate")).toContain(
-      'resource_metadata="https://mcp.exa.ai/.well-known/oauth-protected-resource/mcp"',
+      'resource_metadata="https://mcp.exa.ai/.well-known/oauth-protected-resource/mcp/oauth"',
     );
     expectMcpCorsHeaders(response);
     expect(config).toBeUndefined();
@@ -888,19 +888,35 @@ describe("api/mcp handler", () => {
     expectMcpCorsHeaders(response);
   });
 
-  it("serves OAuth protected resource metadata for the MCP resource", async () => {
+  it("serves OAuth protected resource metadata for the mcp/oauth resource", async () => {
     const { GET } = await import("../../../api/well-known-oauth-protected-resource.js");
 
     const response = GET(
-      new Request("https://mcp.exa.ai/.well-known/oauth-protected-resource/mcp"),
+      new Request(
+        "https://mcp.exa.ai/.well-known/oauth-protected-resource/mcp/oauth?path=mcp/oauth",
+      ),
     );
 
     expect(response.status).toBe(200);
     await expect(response.json()).resolves.toEqual({
-      resource: "https://mcp.exa.ai/mcp",
+      resource: "https://mcp.exa.ai/mcp/oauth",
       authorization_servers: ["https://auth.exa.ai"],
       scopes_supported: ["mcp:tools"],
       bearer_methods_supported: ["header"],
     });
+  });
+
+  it("does not advertise OAuth for the default /mcp resource or the bare request", async () => {
+    const { GET } = await import("../../../api/well-known-oauth-protected-resource.js");
+
+    const defaultResourceResponse = GET(
+      new Request("https://mcp.exa.ai/.well-known/oauth-protected-resource/mcp?path=mcp"),
+    );
+    const barePathResponse = GET(
+      new Request("https://mcp.exa.ai/.well-known/oauth-protected-resource"),
+    );
+
+    expect(defaultResourceResponse.status).toBe(404);
+    expect(barePathResponse.status).toBe(404);
   });
 });

--- a/tests/unit/api/mcp.test.ts
+++ b/tests/unit/api/mcp.test.ts
@@ -726,6 +726,56 @@ describe("api/mcp handler", () => {
     },
   );
 
+  it("forces OAuth for a user agent listed in OAUTH_USER_AGENTS when no credentials are present", async () => {
+    process.env.OAUTH_USER_AGENTS = "ChatGPT, MyConnector";
+
+    const { response, config } = await callHandleRequest(
+      new Request("https://mcp.exa.ai/mcp", {
+        headers: { "user-agent": "ChatGPT/1.0 (connector)" },
+      }),
+    );
+
+    expect(response.status).toBe(401);
+    expect(response.headers.get("WWW-Authenticate")).toContain(
+      'resource_metadata="https://mcp.exa.ai/.well-known/oauth-protected-resource/mcp/oauth"',
+    );
+    expect(config).toBeUndefined();
+    expect(initializeMcpServerMock).not.toHaveBeenCalled();
+  });
+
+  it("does not force OAuth for a matching user agent that already provides an API key", async () => {
+    // The whole point of the opt-out: a client carrying a key must never be
+    // bounced into OAuth, even if its user agent is on the force list.
+    process.env.OAUTH_USER_AGENTS = "ChatGPT";
+
+    const { response, config } = await callHandleRequest(
+      new Request("https://mcp.exa.ai/mcp", {
+        headers: { "user-agent": "ChatGPT/1.0", "x-api-key": "user-key" },
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(config).toMatchObject({
+      exaApiKey: "user-key",
+      userProvidedApiKey: true,
+      authMethod: "api_key",
+    });
+    expect(initializeMcpServerMock).toHaveBeenCalled();
+  });
+
+  it("forces OAuth for plugin clients (?client=…plugin) when no credentials are present", async () => {
+    const { response, config } = await callHandleRequest(
+      new Request("https://mcp.exa.ai/mcp?client=claude-code-plugin"),
+    );
+
+    expect(response.status).toBe(401);
+    expect(response.headers.get("WWW-Authenticate")).toContain(
+      'resource_metadata="https://mcp.exa.ai/.well-known/oauth-protected-resource/mcp/oauth"',
+    );
+    expect(config).toBeUndefined();
+    expect(initializeMcpServerMock).not.toHaveBeenCalled();
+  });
+
   it("uses the internal bypass API key without treating it as user-provided", async () => {
     process.env.RATE_LIMIT_BYPASS = "BypassClient";
     process.env.EXA_API_KEY_BYPASS = "bypass-key";

--- a/tests/unit/api/mcp.test.ts
+++ b/tests/unit/api/mcp.test.ts
@@ -675,6 +675,57 @@ describe("api/mcp handler", () => {
     expect(initializeMcpServerMock).toHaveBeenCalled();
   });
 
+  it("challenges ?login toward an OAuth resource whose metadata is actually served (end-to-end)", async () => {
+    // Making OAuth opt-in turned the default /mcp resource into a 404 at the
+    // metadata endpoint, so ?login must steer clients at the one resource that
+    // still serves metadata (mcp/oauth). Otherwise discovery dead-ends on a 404
+    // and the login flow silently breaks. Walk the whole loop to prove it closes.
+    const { response } = await callHandleRequest(
+      new Request("https://mcp.exa.ai/mcp?login&tools=web_search_exa"),
+    );
+
+    expect(response.status).toBe(401);
+    const resourceMetadata = response.headers
+      .get("WWW-Authenticate")
+      ?.match(/resource_metadata="([^"]+)"/)?.[1];
+    expect(resourceMetadata).toBe(
+      "https://mcp.exa.ai/.well-known/oauth-protected-resource/mcp/oauth",
+    );
+
+    // Follow that URL as an RFC 9728 client would. The vercel.json rewrite forwards
+    // the resource-path suffix along as ?path=, so replay that mapping here.
+    const metadataUrl = new URL(resourceMetadata!);
+    metadataUrl.searchParams.set(
+      "path",
+      metadataUrl.pathname.replace("/.well-known/oauth-protected-resource/", ""),
+    );
+
+    const { GET } = await import("../../../api/well-known-oauth-protected-resource.js");
+    const metadataResponse = GET(new Request(metadataUrl.toString()));
+
+    expect(metadataResponse.status).toBe(200);
+    await expect(metadataResponse.json()).resolves.toMatchObject({
+      resource: "https://mcp.exa.ai/mcp/oauth",
+      authorization_servers: ["https://auth.exa.ai"],
+    });
+  });
+
+  it.each(["login=1", "login=yes"])(
+    "treats ?%s as an OAuth opt-in challenging toward mcp/oauth",
+    async (query) => {
+      const { response, config } = await callHandleRequest(
+        new Request(`https://mcp.exa.ai/mcp?${query}`),
+      );
+
+      expect(response.status).toBe(401);
+      expect(response.headers.get("WWW-Authenticate")).toContain(
+        'resource_metadata="https://mcp.exa.ai/.well-known/oauth-protected-resource/mcp/oauth"',
+      );
+      expect(config).toBeUndefined();
+      expect(initializeMcpServerMock).not.toHaveBeenCalled();
+    },
+  );
+
   it("uses the internal bypass API key without treating it as user-provided", async () => {
     process.env.RATE_LIMIT_BYPASS = "BypassClient";
     process.env.EXA_API_KEY_BYPASS = "bypass-key";

--- a/tests/unit/utils/auth.test.ts
+++ b/tests/unit/utils/auth.test.ts
@@ -1,0 +1,117 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// jose does remote JWKS fetching + signature verification. Mock it so we can
+// drive the claim-shaping logic in verifyOAuthToken deterministically and
+// offline. The hoisted mocks keep a stable identity across vi.resetModules().
+const { jwtVerifyMock, createRemoteJWKSetMock } = vi.hoisted(() => ({
+  jwtVerifyMock: vi.fn(),
+  createRemoteJWKSetMock: vi.fn(() => "fake-jwks"),
+}));
+
+vi.mock("jose", () => ({
+  jwtVerify: jwtVerifyMock,
+  createRemoteJWKSet: createRemoteJWKSetMock,
+}));
+
+async function importAuth() {
+  return import("../../../src/utils/auth.js");
+}
+
+describe("src/utils/auth", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    createRemoteJWKSetMock.mockReturnValue("fake-jwks");
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+    // Force the module to load with its default issuer/audience.
+    delete process.env.OAUTH_ISSUER;
+    delete process.env.OAUTH_AUDIENCE;
+  });
+
+  describe("isJwtToken", () => {
+    it("accepts three non-empty base64url segments", async () => {
+      const { isJwtToken } = await importAuth();
+      expect(isJwtToken("aGVhZGVy.cGF5bG9hZA.c2lnbmF0dXJl")).toBe(true);
+      expect(isJwtToken("aA.bB.cC-_")).toBe(true);
+    });
+
+    it("rejects tokens that are not exactly three dot-separated segments", async () => {
+      const { isJwtToken } = await importAuth();
+      expect(isJwtToken("plain-exa-api-key")).toBe(false);
+      expect(isJwtToken("only.two")).toBe(false);
+      expect(isJwtToken("a.b.c.d")).toBe(false);
+    });
+
+    it("rejects empty segments and non-base64url characters", async () => {
+      const { isJwtToken } = await importAuth();
+      expect(isJwtToken("a..c")).toBe(false);
+      expect(isJwtToken("a.b.")).toBe(false);
+      expect(isJwtToken("has+plus.and/slash.pad=")).toBe(false);
+      expect(isJwtToken("has space.b.c")).toBe(false);
+    });
+  });
+
+  describe("verifyOAuthToken", () => {
+    it("returns validated claims including the exa:api_key_id claim when present", async () => {
+      jwtVerifyMock.mockResolvedValue({
+        payload: {
+          sub: "user-1",
+          "exa:team_id": "team-1",
+          "exa:api_key_id": "key-abc",
+          scope: "mcp:tools",
+        },
+      });
+
+      const { verifyOAuthToken } = await importAuth();
+      await expect(verifyOAuthToken("jwt")).resolves.toEqual({
+        sub: "user-1",
+        "exa:team_id": "team-1",
+        "exa:api_key_id": "key-abc",
+        scope: "mcp:tools",
+      });
+    });
+
+    it("omits exa:api_key_id when the claim is absent (scope stays present but undefined)", async () => {
+      jwtVerifyMock.mockResolvedValue({
+        payload: { sub: "user-1", "exa:team_id": "team-1" },
+      });
+
+      const { verifyOAuthToken } = await importAuth();
+      const claims = await verifyOAuthToken("jwt");
+
+      expect(claims).toMatchObject({ sub: "user-1", "exa:team_id": "team-1" });
+      expect(claims).not.toHaveProperty("exa:api_key_id");
+      expect(claims?.scope).toBeUndefined();
+    });
+
+    it("verifies against the configured issuer and audience", async () => {
+      jwtVerifyMock.mockResolvedValue({
+        payload: { sub: "s", "exa:team_id": "team-1" },
+      });
+
+      const { verifyOAuthToken } = await importAuth();
+      await verifyOAuthToken("jwt");
+
+      expect(jwtVerifyMock).toHaveBeenCalledWith("jwt", "fake-jwks", {
+        issuer: "https://auth.exa.ai",
+        audience: "https://mcp.exa.ai",
+      });
+    });
+
+    it("returns null when the required exa:team_id claim is missing", async () => {
+      jwtVerifyMock.mockResolvedValue({
+        payload: { sub: "user-1", "exa:api_key_id": "key-abc" },
+      });
+
+      const { verifyOAuthToken } = await importAuth();
+      await expect(verifyOAuthToken("jwt")).resolves.toBeNull();
+    });
+
+    it("returns null when verification throws (bad signature, expiry, wrong issuer/audience)", async () => {
+      jwtVerifyMock.mockRejectedValue(new Error("signature verification failed"));
+
+      const { verifyOAuthToken } = await importAuth();
+      await expect(verifyOAuthToken("jwt")).resolves.toBeNull();
+    });
+  });
+});


### PR DESCRIPTION
OAuth-capable MCP clients (Claude, Cursor, VS Code, ChatGPT connectors) probe `/.well-known/oauth-protected-resource` on connect with no credentials, and the endpoint advertised `authorization_servers` for every resource path — so clients auto-started an OAuth flow even when a key was supplied via `?exaApiKey=` or a header. This makes OAuth strictly opt-in: only the dedicated `mcp/oauth` resource serves protected-resource metadata, while the default `/mcp` resource and the bare probe now return `404`. Every OAuth challenge (`?login`, plugin clients, matching user-agents, key-gated tools, expired JWT) now points `resource_metadata` at `mcp/oauth`, so opt-in discovery still works and the `?exaApiKey=`/free-tier path is unaffected. Updates `tests/unit/api/mcp.test.ts` accordingly (all 151 tests pass, typecheck clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)