### PR TITLE
Set openWorldHint on web search and fetch tools

### DIFF
--- a/src/tools/webFetch.ts
+++ b/src/tools/webFetch.ts
@@ -62,7 +62,7 @@ Returns: Clean text content and metadata from the page(s).`,
     {
       readOnlyHint: true,
       destructiveHint: false,
-      openWorldHint: false,
+      openWorldHint: true,
       idempotentHint: true,
     },
     async ({ urls, maxCharacters }) => {

--- a/src/tools/webSearch.ts
+++ b/src/tools/webSearch.ts
@@ -43,7 +43,7 @@ export function registerWebSearchTool(
     {
       readOnlyHint: true,
       destructiveHint: false,
-      openWorldHint: false,
+      openWorldHint: true,
       idempotentHint: true,
     },
     async ({ query, numResults }) => {


### PR DESCRIPTION
## Summary
- Set `openWorldHint: true` on `web_search_exa` and `web_fetch_exa`

## Test plan
- [ ] Verify tool annotations in MCP client