### PR TITLE
Add context-cost badge (486 tokens — well under the 2,636 median)

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
 
 <p align="center">Connect AI agents to Exa for web search, content fetching, and multi-step research.</p>
 
+<p align="center"><a href="https://athakur3.github.io/mcp-context-cost/METHODOLOGY"><img src="https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2Fathakur3%2Fmcp-context-cost%2Fmain%2Fbadges%2Fexa.json" alt="context cost" /></a></p>
+
 <p align="center">
   <a href="https://cursor.com/en/install-mcp?name=exa&config=eyJ1cmwiOiJodHRwczovL21jcC5leGEuYWkvbWNwIn0="><img src="https://custom-icon-badges.demolab.com/badge/Install_in_Cursor-000000?style=for-the-badge&logo=cursor-ai-white" alt="Install in Cursor" /></a>
   <a href="https://vscode.dev/redirect/mcp/install?name=exa&config=%7B%22type%22%3A%22http%22%2C%22url%22%3A%22https%3A%2F%2Fmcp.exa.ai%2Fmcp%22%7D"><img src="https://custom-icon-badges.demolab.com/badge/Install_in_VS_Code-007ACC?style=for-the-badge&logo=vsc&logoColor=white" alt="Install in VS Code" /></a>


### PR DESCRIPTION
One line: a shields.io badge showing what exa-mcp-server's tool schemas cost in context tokens — currently **486 tokens across 2 tools** (`web_search_exa`: 289, `web_fetch_exa`: 195), measured 2026-08-16. Among 57 popular MCP servers we measured, the median is 2,636 — Exa's stdio server is one of the leaner search servers, which seemed worth letting the README say.

The badge JSON lives in [our repo](https://github.com/athakur3/mcp-context-cost) and refreshes weekly; the number links to a reproducible methodology — raw `tools/list` capture + pinned `o200k_base` tokenizer, re-derivable in five lines from [results/exa/measurement.json](https://github.com/athakur3/mcp-context-cost/blob/main/results/exa/measurement.json).

If you'd rather not carry this, close freely — no hard feelings. To own the number in your own CI instead: sd2k/mcp-tokens-action (badge support proposed in sd2k/mcp-tokens-action#5).