### PR TITLE
docs: clarify authentication header syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,6 @@ The hosted MCP server works anonymously with rate limits. For higher limits and 
 
 **OAuth** is preferred: most clients prompt you to sign in to Exa. To force the login flow (useful for shared connectors and plugins), use `https://mcp.exa.ai/mcp?login` or `https://mcp.exa.ai/mcp/oauth`.
 
-If you prefer, you can get an API key from the [dashboard](https://dashboard.exa.ai/api-keys) and pass it on the URL as `?exaApiKey=…`. You can also send it as a `Authorization: Bearer …` header or an `x-api-key` header.
+If you prefer, you can get an API key from the [dashboard](https://dashboard.exa.ai/api-keys) and pass it on the URL as `?exaApiKey=…`. You can also send it in an `Authorization: Bearer <token>` header or an `x-api-key` header.
 
 Built with ❤️ by Exa

--- a/tests/unit/readme-auth.test.ts
+++ b/tests/unit/readme-auth.test.ts
@@ -1,0 +1,13 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+describe("README authentication guidance", () => {
+  it("documents complete Bearer and x-api-key header syntax", () => {
+    const readme = readFileSync(resolve(process.cwd(), "README.md"), "utf8");
+
+    expect(readme).toContain(
+      "If you prefer, you can get an API key from the [dashboard](https://dashboard.exa.ai/api-keys) and pass it on the URL as `?exaApiKey=…`. You can also send it in an `Authorization: Bearer <token>` header or an `x-api-key` header.",
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- repair the malformed Bearer authentication-header example in the README
- state the complete `Authorization: Bearer <token>` and `x-api-key` header alternatives
- add a regression test for the complete authentication guidance

## Verification
- `npx vitest run tests/unit/readme-auth.test.ts`
- `npm run format:check`
- `npm run typecheck`
- `npm test`
- `npm run build`

The build emits the repository's existing `import.meta`-under-CJS warnings.