### PR TITLE
Treat EXA_API_KEY as the caller's key in the container runtime

### DIFF
--- a/src/runtime-server.ts
+++ b/src/runtime-server.ts
@@ -17,7 +17,14 @@ async function toRequest(request: IncomingMessage, body: Buffer): Promise<Reques
     }
   }
 
-  return new Request(`http://${HOST}:${PORT}${request.url || "/"}`, {
+  const url = new URL(request.url || "/", `http://${HOST}:${PORT}`);
+  const hasInboundApiKey =
+    headers.has("x-api-key") || headers.has("authorization") || url.searchParams.has("exaApiKey");
+  if (!hasInboundApiKey && process.env.EXA_API_KEY) {
+    headers.set("x-api-key", process.env.EXA_API_KEY);
+  }
+
+  return new Request(url, {
     method: request.method,
     headers,
     body:


### PR DESCRIPTION
Running the container image with an `EXA_API_KEY` env var and `agent_run` enabled currently 401s on every request, including `initialize`.