### PR TITLE
Publish the AgentCore image as a single-arch Docker manifest

### DIFF
--- a/.github/workflows/publish-agentcore.yml
+++ b/.github/workflows/publish-agentcore.yml
@@ -87,7 +87,9 @@ jobs:
             --platform linux/arm64 \
             --file Dockerfile \
             --tag "${image}" \
-            --push \
+            --provenance=false \
+            --sbom=false \
+            --output type=registry,oci-mediatypes=false \
             --metadata-file "${METADATA_FILE}" \
             .
 


### PR DESCRIPTION
The `v*` release workflow publishes with buildx's default attestations, which forces a manifest index (and OCI media types) instead of the plain single-arch manifest that AWS Marketplace has actually accepted for this image:

```
-  --push
+  --provenance=false --sbom=false
+  --output type=registry,oci-mediatypes=false
```

Verified against a throwaway local registry with the workflow's exact invocation:

- before: `application/vnd.oci.image.index.v1+json` (arm64 manifest + a separate attestation manifest)
- after: `application/vnd.docker.distribution.manifest.v2+json`, single manifest, Docker layer media types

The after shape matches the 3.4.0 and 3.4.1 images that passed Marketplace assessment, so a tagged release produces the same artifact shape AWS has already validated rather than a differently-shaped one discovered mid-assessment. `--output type=registry` is `--push`, spelled long-form so the media-type option can ride along; digest extraction from the metadata file is unchanged.