### PR TITLE
Publish releases from the package.json version

### DIFF
--- a/.github/workflows/publish-agentcore.yml
+++ b/.github/workflows/publish-agentcore.yml
@@ -2,14 +2,11 @@ name: Publish AgentCore image
 
 on:
   push:
-    tags:
-      - "v*"
+    branches:
+      - main
+    paths:
+      - package.json
   workflow_dispatch:
-    inputs:
-      version:
-        description: Image version to publish
-        required: true
-        type: string
 
 permissions:
   contents: read
@@ -29,21 +26,13 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Validate release configuration
-        env:
-          TAG_NAME: ${{ github.ref_name }}
-          VERSION_INPUT: ${{ inputs.version }}
         run: |
           set -euo pipefail
 
           : "${ECR_REPOSITORY_URI:?Set the AGENTCORE_ECR_REPOSITORY_URI repository variable}"
           : "${AWS_ROLE_ARN:?Set the AGENTCORE_AWS_ROLE_ARN repository secret}"
 
-          if [[ "${GITHUB_EVENT_NAME}" == "workflow_dispatch" ]]; then
-            version="${VERSION_INPUT}"
-          else
-            version="${TAG_NAME}"
-          fi
-          version="${version#v}"
+          version="$(node -p "require('./package.json').version")"
 
           if [[ -z "${version}" || "${version}" == *[!0-9A-Za-z._-]* ]]; then
             echo "Version must contain only letters, numbers, dots, underscores, and hyphens." >&2
@@ -58,8 +47,13 @@ jobs:
             exit 1
           fi
 
-          echo "IMAGE_VERSION=${version}" >> "${GITHUB_ENV}"
-          echo "ECR_REGISTRY=${ECR_REPOSITORY_URI%%/*}" >> "${GITHUB_ENV}"
+          registry="${ECR_REPOSITORY_URI%%/*}"
+          {
+            echo "IMAGE_VERSION=${version}"
+            echo "ECR_REGISTRY=${registry}"
+            echo "ECR_REGISTRY_ID=${registry%%.*}"
+            echo "ECR_REPOSITORY_NAME=${ECR_REPOSITORY_URI#*/}"
+          } >> "${GITHUB_ENV}"
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
@@ -67,16 +61,45 @@ jobs:
           aws-region: ${{ env.AWS_REGION }}
           role-to-assume: ${{ secrets.AGENTCORE_AWS_ROLE_ARN }}
 
+      - name: Check for existing Marketplace image
+        id: check-existing-image
+        run: |
+          set -euo pipefail
+
+          set +e
+          response="$(aws ecr describe-images \
+            --region "${AWS_REGION}" \
+            --registry-id "${ECR_REGISTRY_ID}" \
+            --repository-name "${ECR_REPOSITORY_NAME}" \
+            --image-ids "imageTag=${IMAGE_VERSION}" 2>&1)"
+          status=$?
+          set -e
+
+          if [[ "${status}" -eq 0 ]]; then
+            echo "Marketplace image ${ECR_REPOSITORY_URI}:${IMAGE_VERSION} already exists."
+            echo "${response}"
+            echo "skip=true" >> "${GITHUB_OUTPUT}"
+          elif [[ "${response}" == *"ImageNotFoundException"* ]]; then
+            echo "Marketplace image ${ECR_REPOSITORY_URI}:${IMAGE_VERSION} is not published yet."
+            echo "skip=false" >> "${GITHUB_OUTPUT}"
+          else
+            echo "${response}" >&2
+            exit "${status}"
+          fi
+
       - name: Set up Docker Buildx
+        if: steps.check-existing-image.outputs.skip != 'true'
         uses: docker/setup-buildx-action@v3
 
       - name: Log in to AWS Marketplace ECR
+        if: steps.check-existing-image.outputs.skip != 'true'
         run: |
           set -euo pipefail
           aws ecr get-login-password --region "${AWS_REGION}" |
             docker login --username AWS --password-stdin "${ECR_REGISTRY}"
 
       - name: Build and push ARM64 image
+        if: steps.check-existing-image.outputs.skip != 'true'
         env:
           METADATA_FILE: ${{ runner.temp }}/agentcore-image-metadata.json
         run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,6 +1,11 @@
 name: Publish
 
 on:
+  push:
+    branches:
+      - main
+    paths:
+      - package.json
   workflow_dispatch:
 
 permissions:
@@ -27,5 +32,29 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Check whether the package version is already published
+        id: check-existing-version
+        run: |
+          set -euo pipefail
+
+          version="$(node -p "require('./package.json').version")"
+          set +e
+          response="$(npm view "exa-mcp-server@${version}" version 2>&1)"
+          status=$?
+          set -e
+
+          if [[ "${status}" -eq 0 && "${response}" == "${version}" ]]; then
+            echo "npm version ${version} is already published."
+            echo "skip=true" >> "${GITHUB_OUTPUT}"
+          elif [[ "${status}" -ne 0 && "${response}" == *"E404"* ]]; then
+            echo "npm version ${version} is not published yet."
+            echo "skip=false" >> "${GITHUB_OUTPUT}"
+          else
+            echo "Unexpected response while checking npm version ${version}:" >&2
+            echo "${response}" >&2
+            exit "${status}"
+          fi
+
       - name: Publish
+        if: steps.check-existing-version.outputs.skip != 'true'
         run: npm publish --access public


### PR DESCRIPTION
Releases were tied to a hand-typed `v*` git tag that this repo has never used (zero tags exist), while npm publishing was a `workflow_dispatch` button off `main`. That meant two triggers per release and two places for the version to drift.

Now `package.json`'s `version` is the single source of truth: merging a version-bump commit to `main` publishes both npm and the AgentCore container image at that version. `workflow_dispatch` stays as a manual re-run and also reads `package.json`, so no version is ever typed by hand.

Because `package.json` also changes for dependency bumps, each workflow first checks whether that version is already published (`aws ecr describe-images` for the Marketplace image, `npm view` for the package) and skips the publish steps cleanly instead of failing.

Image build behaviour is unchanged: linux/arm64 only, no provenance/SBOM, Docker media types, no `latest` tag.
